### PR TITLE
Improvements to composer and Drupal commands

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,11 +1,1 @@
-version: '3'
-
-dotenv: ['.env']
-
-includes:
-  drupal: ./vendor/lullabot/drainpipe/tasks/drupal.yml
-
-tasks:
-  default:
-    cmds:
-      - echo "Hello, world!"
+scaffold/Taskfile.yml

--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -4,8 +4,3 @@ dotenv: ['.env']
 
 includes:
   drupal: ./vendor/lullabot/drainpipe/tasks/drupal.yml
-
-tasks:
-  default:
-    cmds:
-      - echo "Hello, world!"

--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+dotenv: ['.env']
+
+includes:
+  drupal: ./vendor/lullabot/drainpipe/tasks/drupal.yml
+
+tasks:
+  default:
+    cmds:
+      - echo "Hello, world!"

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -4,7 +4,7 @@ tasks:
   build:
     desc: Build Drupal for production usage.
     cmds:
-      - composer install --no-dev
+      - composer install --no-dev --optimize-autoloader
     status:
       - test -f ./vendor/composer/installed.json
       - test -f ./vendor/composer/autoload.php

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -1,24 +1,14 @@
 version: '3'
 
 tasks:
-  build:
+  # We intentionally do not include a command for development installations.
+  # Since we need to bootstrap fresh clones from git with `composer install`,
+  # being able to execute this task means that development files are already
+  # available.
+  build:prod:
     desc: Build Drupal for production usage.
     cmds:
       - composer install --no-dev --optimize-autoloader
-    sources:
-      - composer.json
-      - composer.lock
-    generates:
-      - ./vendor/composer/installed.json
-      - ./vendor/autoload.php
-    status:
-      - >
-        test -f ./vendor/composer/installed.json && grep -q '"dev": true' ./vendor/composer/installed.json
-
-  build:dev:
-    desc: Build Drupal for development usage.
-    cmds:
-      - composer install
     sources:
       - composer.json
       - composer.lock
@@ -41,10 +31,12 @@ tasks:
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes config:import
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes updatedb --no-cache-clear
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes cache:rebuild
+
   maintenance:on:
     desc: Turn on Maintenance Mode.
     cmds:
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes state:set system.maintenance_mode 1 --input-format=integer
+
   maintenance:off:
     desc: Turn off Maintenance Mode.
     cmds:

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -9,15 +9,17 @@ tasks:
     desc: Build Drupal for production usage.
     cmds:
       - composer install --no-dev --optimize-autoloader
-    sources:
-      - composer.json
-      - composer.lock
-    generates:
-      - ./vendor/composer/installed.json
-      - ./vendor/autoload.php
-    status:
-      - >
-        test -f ./vendor/composer/installed.json && grep -q '"dev": false' ./vendor/composer/installed.json
+    # Disabled until https://github.com/go-task/task/pull/477 is merged and
+    # released.
+    # sources:
+    #   - composer.json
+    #   - composer.lock
+    # generates:
+    #   - ./vendor/composer/installed.json
+    #   - ./vendor/autoload.php
+    # status:
+    #   - >
+    #     test -f ./vendor/composer/installed.json && grep -q '"dev": false' ./vendor/composer/installed.json
 
   update:
     desc: Run Drupal update tasks after deploying new code.

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -7,7 +7,16 @@ tasks:
       - composer install --no-dev --optimize-autoloader
     status:
       - test -f ./vendor/composer/installed.json
-      - test -f ./vendor/composer/autoload.php
+      - test -f ./vendor/autoload.php
+
+  build:dev:
+    desc: Build Drupal for development usage.
+    cmds:
+      - composer install
+    status:
+      - test -f ./vendor/composer/installed.json
+      - test -f ./vendor/autoload.php
+
   update:
     desc: Run Drupal update tasks after deploying new code.
     cmds:

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -5,17 +5,29 @@ tasks:
     desc: Build Drupal for production usage.
     cmds:
       - composer install --no-dev --optimize-autoloader
+    sources:
+      - composer.json
+      - composer.lock
+    generates:
+      - ./vendor/composer/installed.json
+      - ./vendor/autoload.php
     status:
-      - test -f ./vendor/composer/installed.json
-      - test -f ./vendor/autoload.php
+      - >
+        test -f ./vendor/composer/installed.json && grep -q '"dev": true' ./vendor/composer/installed.json
 
   build:dev:
     desc: Build Drupal for development usage.
     cmds:
       - composer install
+    sources:
+      - composer.json
+      - composer.lock
+    generates:
+      - ./vendor/composer/installed.json
+      - ./vendor/autoload.php
     status:
-      - test -f ./vendor/composer/installed.json
-      - test -f ./vendor/autoload.php
+      - >
+        test -f ./vendor/composer/installed.json && grep -q '"dev": false' ./vendor/composer/installed.json
 
   update:
     desc: Run Drupal update tasks after deploying new code.

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -2,12 +2,14 @@ version: '3'
 
 tasks:
   build:
+    desc: Build Drupal for production usage.
     cmds:
       - composer install --no-dev
     status:
       - test -f ./vendor/composer/installed.json
       - test -f ./vendor/composer/autoload.php
   update:
+    desc: Run Drupal update tasks after deploying new code.
     cmds:
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes cache:clear plugin
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes updatedb --no-post-updates
@@ -19,8 +21,10 @@ tasks:
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes updatedb --no-cache-clear
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes cache:rebuild
   mainton:
+    desc: Turn on Maintenance Mode.
     cmds:
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes state:set system.maintenance_mode 1 --input-format=integer
   maintoff:
+    desc: Turn off Maintenance Mode.
     cmds:
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes state:set system.maintenance_mode 0 --input-format=integer

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -20,11 +20,11 @@ tasks:
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes config:import
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes updatedb --no-cache-clear
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes cache:rebuild
-  mainton:
+  maintenance:on:
     desc: Turn on Maintenance Mode.
     cmds:
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes state:set system.maintenance_mode 1 --input-format=integer
-  maintoff:
+  maintenance:off:
     desc: Turn off Maintenance Mode.
     cmds:
       - ./vendor/bin/drush {{.CLI_ARGS}} --yes state:set system.maintenance_mode 0 --input-format=integer


### PR DESCRIPTION
This is a bit of a grab-bag of a PR, but the actual number of changed lines is fairly small:

1. Moves `Taskfile.yml` into a subdirectory so we can eventually add one for this project if we want. It's symlinked for now since the installer plugin still looks into the root.
2. Makes it clear the build command is _for production_ use. Otherwise, having a basic "composer install" is not actually useful since we need to run that first to get the taskfile for fresh git checkouts.
3. Switches from checking the existence of generated files to hashing them. Also checks the installed.json file to see if we are including dev dependencies or not.
4. Spells out and namespaces the maintenance mode commands, to make it easier for new users to understand.