### PR TITLE
Issue #9: Add a helper for ddev to run task easily

### DIFF
--- a/scaffold/ddev/task-command.sh
+++ b/scaffold/ddev/task-command.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Run Taskfile commands inside web container
+## Usage: task
+## Example: "ddev task build"
+
+task "$@"

--- a/scaffold/ddev/task-command.sh
+++ b/scaffold/ddev/task-command.sh
@@ -4,4 +4,4 @@
 ## Usage: task
 ## Example: "ddev task build"
 
-task "$@"
+./vendor/bin/task "$@"

--- a/src/TaskfileInstallerPlugin.php
+++ b/src/TaskfileInstallerPlugin.php
@@ -71,6 +71,7 @@ class TaskfileInstallerPlugin implements PluginInterface, EventSubscriberInterfa
     {
         $this->installTaskfile();
         $this->installGitignore();
+        $this->installDdevCommand();
     }
 
     /**
@@ -82,6 +83,7 @@ class TaskfileInstallerPlugin implements PluginInterface, EventSubscriberInterfa
     {
         $this->installTaskfile();
         $this->installGitignore();
+        $this->installDdevCommand();
     }
 
     /**
@@ -140,6 +142,20 @@ class TaskfileInstallerPlugin implements PluginInterface, EventSubscriberInterfa
                     )
                 );
             }
+        }
+    }
+
+    /**
+     *
+     */
+    private function installDdevCommand(): void
+    {
+        if (file_exists('./.ddev/config.yaml')) {
+            $vendor = $this->config->get('vendor-dir');
+            $ddevCommandPath = $vendor.'/lullabot/drainpipe/scaffold/ddev/task-command.sh';
+            $fs = new Filesystem();
+            $fs->ensureDirectoryExists('./.ddev/commands/web');
+            $fs->copy($ddevCommandPath, './.ddev/commands/web/task');
         }
     }
 }


### PR DESCRIPTION
…includes

## Testing Instructions
- [x] Run `composer create-project drupal/recommended-project drainpipe-test`
- [x] Install [ddev](https://ddev.readthedocs.io/en/stable/)
- [x] In drainpipe-test run `ddev config`
- [x] In drainpipe-test run `ddev start`
- [x] Inside the web container, check out this repo and branch
- [x] Add this to the repositories key in composer.json of drainpipe-test:
```
        {
            "type": "path",
            "version": "dev-main",
            "url": "/path/to/drainpipe",
            "options": {
                "symlink": false
            }
        },
```
- [x] Run `ddev composer require lullabot/drainpipe:dev-main`
- [x] Run `ddev task --list`