### PR TITLE
Allow Symfony 3 for Drupal 8 sites

### DIFF
--- a/.github/workflows/test-production-build.yml
+++ b/.github/workflows/test-production-build.yml
@@ -39,7 +39,7 @@ jobs:
           cd drupal
           cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/composer.json .
           cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/Taskfile.yml .
-          composer install ${{ matrix.composer-flags }}
+          composer update ${{ matrix.composer-flags }}
       - name: Run static tests
         run: |
           cd ../drupal

--- a/.github/workflows/test-production-build.yml
+++ b/.github/workflows/test-production-build.yml
@@ -9,11 +9,18 @@ on:
 jobs:
   Test-Production-Build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [7.3, 7.4, 8.0]
+        include:
+          - php-version: 7.3
+            composer-flags: --prefer-lowest --prefer-stable
+
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-version }}
           tools: composer:v2
           extensions: gd
       - name: Get composer cache directory
@@ -32,7 +39,7 @@ jobs:
           cd drupal
           cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/composer.json .
           cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/Taskfile.yml .
-          composer install
+          composer install ${{ matrix.composer-flags }}
       - name: Run static tests
         run: |
           cd ../drupal

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.3||^8.0",
         "composer-plugin-api": "^2.0",
         "drush/drush": "^10.5",
-        "symfony/yaml": "^4"
+        "symfony/yaml": "^3|^4"
     },
     "require-dev": {
         "composer/composer": "^2.0",

--- a/tests/fixtures.drainpipe-test-build/composer.json
+++ b/tests/fixtures.drainpipe-test-build/composer.json
@@ -23,10 +23,10 @@
   ],
   "require": {
     "composer/installers": "^1.9",
-    "drupal/core": "^9.2",
-    "drupal/core-composer-scaffold": "^9.2",
-    "drupal/core-project-message": "^9.2",
-    "drupal/core-recommended": "^9.2",
+    "drupal/core": "^8.9|^9.2",
+    "drupal/core-composer-scaffold": "^8.9|^9.2",
+    "drupal/core-project-message": "^8.9|^9.2",
+    "drupal/core-recommended": "^8.9|^9.2",
     "lullabot/drainpipe": "*"
   },
   "conflict": {


### PR DESCRIPTION
I went to add Drainpipe to The Daily Report, thinking it would be good to do that _before_ we do the Drupal 9 upgrade. However, drainpipe requires `symfony/yaml` 4, and Drupal 8.9 is on Symfony 3. It wouldn't surprise me if we have inherited projects that need to update to Drupal 9 but have some cleanups to do first, even past the official Drupal 8 EOL.

Also, I got to learn about how GitHub actions handles matrix builds, and they're pretty good 👍 

https://github.com/Lullabot/drainpipe/pull/37/checks?check_run_id=3667614911 shows testing against Drupal 8.9, and https://github.com/Lullabot/drainpipe/pull/37/checks?check_run_id=3667615016 tests against 9.2.