### PR TITLE
Upgrade Task to 3.8.0

### DIFF
--- a/src/BinaryInstallerPlugin.php
+++ b/src/BinaryInstallerPlugin.php
@@ -13,24 +13,24 @@ class BinaryInstallerPlugin extends BinaryInstaller
         'task' => [
             'releases' => [
                 'linux' => [
-                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.4.3/task_linux_amd64.tar.gz', 'sha' => '1492e0d185eb7e8547136c8813e51189f59c1d9e21e5395ede9b9a40d55c796e'],
-                    'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.4.3/task_linux_arm.tar.gz', 'sha' => '5d96701230abe2ce44ab416674431953e177ad949f8be388646a562876fe7921'],
-                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.4.3/task_linux_386.tar.gz', 'sha' => '9a2fe84cfb7a0007360116b69598ba7b1b63ead0ec3ced5f7330864705977f20'],
-                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.4.3/task_linux_arm64.tar.gz', 'sha' => 'd1d56f3fbf54965c0ac5366f8679745f315ca2d4c56f962e73ee8f48bea311ee'],
+                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_amd64.tar.gz', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
+                    'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_arm.tar.gz', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
+                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_386.tar.gz', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
+                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_arm64.tar.gz', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
                 ],
                 'darwin' => [
-                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.4.3/task_darwin_amd64.tar.gz', 'sha' => 'a82117a3b560f35be9d5d34a1eb6707f1cdde1e2ab9ed22cd5a72bd97682a83e'],
-                    // The Macbook M1 will run the amd64 binary in emulation mode.
-                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.4.3/task_darwin_amd64.tar.gz', 'sha' => 'a82117a3b560f35be9d5d34a1eb6707f1cdde1e2ab9ed22cd5a72bd97682a83e'],
+                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_darwin_amd64.tar.gz', 'sha' => '4d59ec362a04d39ae6f1d1a2419071cc1d6230e6bf779e06567927a73d79e475'],
+                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_darwin_arm64.tar.gz', 'sha' => '03129bcbd62aa59409e9147e4c7c3d7aa9b1a1b7946d43581fd99835c781411f'],
                 ],
                 'windows' => [
-                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.4.3/task_windows_amd64.zip', 'sha' => '68633544333abe848f1244c90d2178e7d86d59e8f9c15b8ad2e288266949988a'],
-                    'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.4.3/task_windows_arm.zip', 'sha' => '4001a78451caee56f3146bfce50a2205942963927fe1f570bbd0d7a58fb4551a'],
-                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.4.3/task_windows_386.zip', 'sha' => '72602187b4ddcd89c6c91f862cd14535ae8ee137f07108f4755accf764ba3100'],
+                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_windows_amd64.zip', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
+                    'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_windows_arm.zip', 'sha' => 'cc93110790c011af31bfd35d300e443628cd1649b7cd2d58386770085ec66752'],
+                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_windows_arm64.zip', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
+                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_windows_386.zip', 'sha' => '00dac9b129ccbb2ae019d2ded470c87baec538a9d97e2b74db9b3e6e5e6d179f'],
                 ],
             ],
             'hashalgo' => 'sha256',
-            'version' => '3.4.3',
+            'version' => '3.8.0',
         ],
     ];
 }

--- a/src/BinaryInstallerPlugin.php
+++ b/src/BinaryInstallerPlugin.php
@@ -13,17 +13,17 @@ class BinaryInstallerPlugin extends BinaryInstaller
         'task' => [
             'releases' => [
                 'linux' => [
-                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_amd64.tar.gz', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
-                    'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_arm.tar.gz', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
-                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_386.tar.gz', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
-                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_arm64.tar.gz', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
+                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_amd64.tar.gz', 'sha' => '4d59ec362a04d39ae6f1d1a2419071cc1d6230e6bf779e06567927a73d79e475'],
+                    'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_arm.tar.gz', 'sha' => '6fb247ca632544a20c7c4600f0cdbb9ba388e0c154d053c27721df4d28f5e7c0'],
+                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_386.tar.gz', 'sha' => 'e165c92548e29f794b6176a5f9c16f4a18a39f0723fb2d15a38f28c02833b646'],
+                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_linux_arm64.tar.gz', 'sha' => 'e2c78ce20d8021c4fd86656694a5f0d5248c8dd9b9b5f28628562c88e5acd351'],
                 ],
                 'darwin' => [
-                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_darwin_amd64.tar.gz', 'sha' => '4d59ec362a04d39ae6f1d1a2419071cc1d6230e6bf779e06567927a73d79e475'],
+                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_darwin_amd64.tar.gz', 'sha' => 'db554d151af42eef0609904526c9cf36e2800571d1763f389f4bbf654c7f3535'],
                     'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_darwin_arm64.tar.gz', 'sha' => '03129bcbd62aa59409e9147e4c7c3d7aa9b1a1b7946d43581fd99835c781411f'],
                 ],
                 'windows' => [
-                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_windows_amd64.zip', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
+                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_windows_amd64.zip', 'sha' => '73818d978748ec4d914b7e1209eef54a202fc7e6ebeb2b0bfd991372746c9a73'],
                     'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_windows_arm.zip', 'sha' => 'cc93110790c011af31bfd35d300e443628cd1649b7cd2d58386770085ec66752'],
                     'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_windows_arm64.zip', 'sha' => '6b2567253c9f6b9aaffb39751af0c7ff94c3466bf4c5ec4371fcb00df5485bd3'],
                     '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.8.0/task_windows_386.zip', 'sha' => '00dac9b129ccbb2ae019d2ded470c87baec538a9d97e2b74db9b3e6e5e6d179f'],


### PR DESCRIPTION
## Testing Instructions

- Run `composer require lullabot/drainpipe:dev-justafish/upgrade-task-3.8.0` on a project using Drainpipe (you might need to first remove `drainpipe-dev` if it has a dependency on `dev-main`
- Run `./vendor/bin/task --version` and verify Task has been upgraded to v3.8.0