### PR TITLE
feat: Enable sources/generates/status for composer

### DIFF
--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -10,28 +10,28 @@ tasks:
       anyway to get task and drainpipe.
     cmds:
       - composer install --optimize-autoloader
-      sources:
-        - composer.json
-        - composer.lock
-      generates:
-        - ./vendor/composer/installed.json
-        - ./vendor/autoload.php
-      status:
-        - >
-          test -f ./vendor/composer/installed.json && grep -q '"dev": true' ./vendor/composer/installed.json
+    sources:
+      - composer.json
+      - composer.lock
+    generates:
+      - ./vendor/composer/installed.json
+      - ./vendor/autoload.php
+    status:
+      - >
+        test -f ./vendor/composer/installed.json && grep -q '"dev": true' ./vendor/composer/installed.json
   composer:production:
     desc: Install composer dependencies without devDependencies
     cmds:
       - composer install --no-dev --optimize-autoloader
-     sources:
-       - composer.json
-       - composer.lock
-     generates:
-       - ./vendor/composer/installed.json
-       - ./vendor/autoload.php
-     status:
-       - >
-         test -f ./vendor/composer/installed.json && grep -q '"dev": false' ./vendor/composer/installed.json
+   sources:
+     - composer.json
+     - composer.lock
+   generates:
+     - ./vendor/composer/installed.json
+     - ./vendor/autoload.php
+   status:
+     - >
+       test -f ./vendor/composer/installed.json && grep -q '"dev": false' ./vendor/composer/installed.json
   install:
     desc: "Runs the site installer"
     cmds:

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -23,15 +23,15 @@ tasks:
     desc: Install composer dependencies without devDependencies
     cmds:
       - composer install --no-dev --optimize-autoloader
-   sources:
-     - composer.json
-     - composer.lock
-   generates:
-     - ./vendor/composer/installed.json
-     - ./vendor/autoload.php
-   status:
-     - >
-       test -f ./vendor/composer/installed.json && grep -q '"dev": false' ./vendor/composer/installed.json
+    sources:
+      - composer.json
+      - composer.lock
+    generates:
+      - ./vendor/composer/installed.json
+      - ./vendor/autoload.php
+    status:
+      - >
+        test -f ./vendor/composer/installed.json && grep -q '"dev": false' ./vendor/composer/installed.json
   install:
     desc: "Runs the site installer"
     cmds:

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -1,26 +1,41 @@
 version: '3'
 
 tasks:
-  # We intentionally do not include a command for development installations.
-  # Since we need to bootstrap fresh clones from git with `composer install`,
-  # being able to execute this task means that development files are already
-  # available.
-  build:prod:
-    desc: Build Drupal for production usage
+  composer:development:
+    desc: Install composer dependencies
+    summary: |
+      This command is typically used when a developer updates their local after
+      pulling new changes from source control. Generally when bootstrapping a
+      fresh clone of the site from git, you'll need to run `composer install`
+      anyway to get task and drainpipe.
+    cmds:
+      - composer install --optimize-autoloader
+      sources:
+        - composer.json
+        - composer.lock
+      generates:
+        - ./vendor/composer/installed.json
+        - ./vendor/autoload.php
+      status:
+        - >
+          test -f ./vendor/composer/installed.json && grep -q '"dev": true' ./vendor/composer/installed.json
+  composer:production:
+    desc: Install composer dependencies without devDependencies
     cmds:
       - composer install --no-dev --optimize-autoloader
-    # Disabled until https://github.com/go-task/task/pull/477 is merged and
-    # released.
-    # sources:
-    #   - composer.json
-    #   - composer.lock
-    # generates:
-    #   - ./vendor/composer/installed.json
-    #   - ./vendor/autoload.php
-    # status:
-    #   - >
-    #     test -f ./vendor/composer/installed.json && grep -q '"dev": false' ./vendor/composer/installed.json
-
+     sources:
+       - composer.json
+       - composer.lock
+     generates:
+       - ./vendor/composer/installed.json
+       - ./vendor/autoload.php
+     status:
+       - >
+         test -f ./vendor/composer/installed.json && grep -q '"dev": false' ./vendor/composer/installed.json
+  install:
+    desc: "Runs the site installer"
+    cmds:
+      - ./vendor/bin/drush --yes site:install --existing-config
   update:
     desc: Run Drupal update tasks after deploying new code
     cmds:
@@ -33,12 +48,10 @@ tasks:
       - ./vendor/bin/drush {{.site}} --yes config:import
       - ./vendor/bin/drush {{.site}} --yes updatedb --no-cache-clear
       - ./vendor/bin/drush {{.site}} --yes cache:rebuild
-
   maintenance:on:
     desc: Turn on Maintenance Mode
     cmds:
       - ./vendor/bin/drush {{.site}} --yes state:set system.maintenance_mode 1 --input-format=integer
-
   maintenance:off:
     desc: Turn off Maintenance Mode
     cmds:

--- a/tests/fixtures.drainpipe-test-build/Taskfile.yml
+++ b/tests/fixtures.drainpipe-test-build/Taskfile.yml
@@ -8,8 +8,8 @@ includes:
 
 tasks:
   build:
-    desc: "Production build of the project"
-    deps: [drupal:build:prod]
+    desc: "Production composer install of the project"
+    deps: [drupal:composer:production]
     cmds:
       - if [ ! -f "web/index.php" ]; then exit 1; fi
       - if [ -f "vendor/lullabot/drainpipe-dev/composer.json" ]; then exit 1; fi


### PR DESCRIPTION
Fingerprints locally generated files and their sources to prevent
unnecessary work. Also renames the command to composer:production and
adds a composer:development and install task too.

See Issue #36