### PR TITLE
Use gulp for Sass builds so autoprefixer and cssnano can be used

### DIFF
--- a/config/esbuild.js
+++ b/config/esbuild.js
@@ -15,6 +15,7 @@ const deps = [
 ].join(' ');
 
 try {
+  const fs = require('fs');
   const yargs = require('yargs');
   const { hideBin } = require('yargs/helpers')
   const argv = yargs(hideBin(process.argv)).argv

--- a/config/esbuild.js
+++ b/config/esbuild.js
@@ -1,92 +1,130 @@
-const yargs = require('yargs');
-const { hideBin } = require('yargs/helpers')
-const argv = yargs(hideBin(process.argv)).argv
-const { build } = require('esbuild');
-const chokidar = require('chokidar');
-const { pnpPlugin } = require('@yarnpkg/esbuild-plugin-pnp');
-const scripts = argv.files.split(' ');
-
-
-if (!scripts.length) {
-  console.log('No files to compile');
-  process.exit(0);
+let yarn2 = false;
+try {
+  const { resolveToUnqualified } = require('pnpapi');
+  yarn2 = true;
+}
+catch (error) {
+  // Nothing
 }
 
-const targets = [];
-const sources = [];
+// So they can be easily printed to the user.
+const deps = [
+  'chokidar',
+  'esbuild',
+  'yargs',
+].join(' ');
+
+try {
+  const yargs = require('yargs');
+  const { hideBin } = require('yargs/helpers')
+  const argv = yargs(hideBin(process.argv)).argv
+  const { build } = require('esbuild');
+  const chokidar = require('chokidar');
+  const scripts = argv.files.split(' ');
+
+
+  if (!scripts.length) {
+    console.log('No files to compile');
+    process.exit(0);
+  }
+
+  const targets = [];
+  const sources = [];
 
 // Check that every source/target has the same basedir (probably "web") due to
 // being unable to provide separate entryNames.
 // See https://github.com/evanw/esbuild/issues/224
-const baseDirs = [];
+  const baseDirs = [];
 // Check that the output script name matches the same as the input script name,
 // due to the same limitation above. It can have a different file extension,
 // e.g. web/modules/custom/mymodule/script.js:web/modules/custom/mymodule/script.min.js
-const fileExtensions = [];
-scripts.forEach(script => {
-  const [source, target] = script.split(':');
-  sources.push(source);
-  targets.push(target);
-  baseDirs.push(source.split('/')[0]);
-  baseDirs.push(target.split('/')[0]);
-  const sourceFile = source.split('/').pop();
-  const targetFile = target.split('/').pop();
-  fileExtensions.push(targetFile.split('.', 2)[1]);
-});
-const uniqueBaseDir = [...new Set(baseDirs)];
-if (uniqueBaseDir.length !== 1) {
-  console.error('All source and target files must have a root directory in common');
-  process.exit(1);
-}
-const uniqueFileExtension = [ ...new Set(fileExtensions)];
-if (uniqueFileExtension.length !== 1) {
-  console.error('All target files must have the same file extension e.g. "min.js"');
-  process.exit(1);
-}
-
-
-  (async() => {
-  try {
-    let builder = await build({
-      plugins: [pnpPlugin()],
-      entryPoints: scripts.map(script => script.split(':')[0]),
-      outdir: uniqueBaseDir[0],
-      entryNames: `[dir]/[name].${uniqueFileExtension[0]}`,
-      bundle: true,
-      sourcemap: true,
-      minify: !!argv.minify,
-      incremental: !!argv.watch,
-      logLevel: 'info',
-    });
-
-    if (!!argv.watch) {
-      let ready = false;
-      chokidar.watch(`${uniqueBaseDir[0]}/**/*.js`, {
-        ignored: targets,
-      })
-        .on('ready', () => {
-          ready = true;
-          console.log('[esbuild]', 'watching for changes');
-        })
-        .on('all', (event, path) => {
-          if (ready) {
-            console.log('[esbuild]', event, path);
-            builder.rebuild()
-              .then(result => {
-                console.log('[esbuild]', 'watch build succeeded')
-                if (result.warnings.length) {
-                  console.warn('[esbuild]', 'watch build has warnings', result.warnings);
-                }
-              })
-              .catch(err => {
-                console.error('[esbuild]', 'watch build failed', err);
-              });
-          }
-        });
-    }
-  }
-  catch(err) {
-    console.error(err);
+  const fileExtensions = [];
+  scripts.forEach(script => {
+    const [source, target] = script.split(':');
+    sources.push(source);
+    targets.push(target);
+    baseDirs.push(source.split('/')[0]);
+    baseDirs.push(target.split('/')[0]);
+    const sourceFile = source.split('/').pop();
+    const targetFile = target.split('/').pop();
+    fileExtensions.push(targetFile.split('.', 2)[1]);
+  });
+  const uniqueBaseDir = [...new Set(baseDirs)];
+  if (uniqueBaseDir.length !== 1) {
+    console.error('All source and target files must have a root directory in common');
     process.exit(1);
   }
-})();
+  const uniqueFileExtension = [...new Set(fileExtensions)];
+  if (uniqueFileExtension.length !== 1) {
+    console.error('All target files must have the same file extension e.g. "min.js"');
+    process.exit(1);
+  }
+
+
+  (async () => {
+    try {
+      const plugins = [];
+      if (yarn2) {
+        const { pnpPlugin } = require('@yarnpkg/esbuild-plugin-pnp');
+        plugins.push(pnpPlugin);
+      }
+      let builder = await build({
+        plugins: [plugins],
+        entryPoints: scripts.map(script => script.split(':')[0]),
+        outdir: uniqueBaseDir[0],
+        entryNames: `[dir]/[name].${uniqueFileExtension[0]}`,
+        bundle: true,
+        sourcemap: true,
+        minify: !!argv.minify,
+        incremental: !!argv.watch,
+        logLevel: 'info',
+      });
+
+      if (!!argv.watch) {
+        let ready = false;
+        chokidar.watch(`${uniqueBaseDir[0]}/**/*.js`, {
+          ignored: targets,
+        })
+          .on('ready', () => {
+            ready = true;
+            console.log('[esbuild]', 'watching for changes');
+          })
+          .on('all', (event, path) => {
+            if (ready) {
+              console.log('[esbuild]', event, path);
+              builder.rebuild()
+                .then(result => {
+                  console.log('[esbuild]', 'watch build succeeded')
+                  if (result.warnings.length) {
+                    console.warn('[esbuild]', 'watch build has warnings', result.warnings);
+                  }
+                })
+                .catch(err => {
+                  console.error('[esbuild]', 'watch build failed', err);
+                });
+            }
+          });
+      }
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
+    }
+  })();
+}
+catch (error) {
+  if (error.code !== 'MODULE_NOT_FOUND') {
+    throw error;
+  }
+  console.error('🪠 Missing node dependency! Please run:');
+  if (fs.exists(path.join(__dirname, `package-lock.json`))) {
+    console.error(`npm install ${deps} --save-dev`);
+  }
+  else if (fs.exists(path.join(__dirname, 'yarn.lock'))) {
+    console.error(`yarn add ${deps} @yarnpkg/esbuild-plugin-pnp --dev`);
+  }
+  else {
+    console.error('yarn init');
+    console.error(`yarn add ${deps} @yarnpkg/esbuild-plugin-pnp --dev`);
+  }
+  process.exit(1);
+}

--- a/config/gulpfile.js
+++ b/config/gulpfile.js
@@ -1,0 +1,96 @@
+const path = require('path');
+const fs = require('fs');
+// So they can be easily printed to the user.
+const deps = [
+  'autoprefixer',
+  'cssnano',
+  'gulp',
+  'gulp-sass',
+  'gulp-postcss',
+  'gulp-sourcemaps',
+  'modern-normalize',
+  'sass',
+  'yargs',
+].join(' ');
+
+try {
+  const yargs = require('yargs');
+  const { hideBin } = require('yargs/helpers')
+  const argv = yargs(hideBin(process.argv)).argv
+  const { src, dest, task, watch, series } = require('gulp');
+  const sass = require('gulp-sass')(require('sass'));
+  const dartSass = require('sass');
+  const postcss = require('gulp-postcss');
+  const sourcemaps = require('gulp-sourcemaps');
+  const cssnano = require('cssnano');
+  const autoprefixer = require('autoprefixer');
+  const modernNormalizePath = path.join(path.dirname(require.resolve('modern-normalize')), '..');
+
+  const files = argv.files.split(' ');
+  if (!files.length) {
+    console.log('No files to compile');
+    process.exit(0);
+  }
+
+  const srcs = files
+    .map(file => file.split(':', 2).map(file => path.resolve(file)))
+    .reduce((prev, curr) => {
+      prev[curr.shift()] = curr.shift();
+      return prev;
+    }, {});
+
+  console.log('🪠 Autoprefixer info:');
+  console.log(autoprefixer.info());
+
+  // Compile once with dart Sass directly to get a list of includes/partials.
+  const includes = Object.keys(srcs)
+    .map(file => {
+      const result = dartSass.renderSync({
+        file: file,
+        includePaths: [modernNormalizePath],
+      });
+      return result.stats.includedFiles.filter(file => typeof file === "string");
+    })
+    .reduce((prev, curr) => prev.concat(curr), []);
+
+  task('sass', function() {
+    return src(Object.keys(srcs))
+      .pipe(sourcemaps.init())
+      .pipe(sass.sync({
+        outputStyle: 'compressed',
+        includePaths: [modernNormalizePath],
+      }).on('error', sass.logError))
+      .pipe(postcss([
+        autoprefixer(),
+        cssnano(),
+      ]))
+      .pipe(sourcemaps.write('./'))
+      .pipe(dest((file) => {
+        const originalFile = file.history.shift();
+        const destFile = path.dirname(srcs[originalFile]);
+        console.log(`🪠 Writing ${path.relative(process.cwd(), file.path)}`);
+        return destFile;
+      }));
+  });
+
+  task('sass:watch', function() {
+    watch(includes, series('sass'));
+  });
+}
+catch (error) {
+  if (error.code !== 'MODULE_NOT_FOUND') {
+    throw error;
+  }
+  console.error('🪠 Missing node dependency! Please run:');
+  if (fs.exists(path.join(__dirname, `package-lock.json`))) {
+    console.error(`npm install ${deps} --save-dev`);
+  }
+  else if (fs.exists(path.join(__dirname, 'yarn.lock'))) {
+    console.error(`yarn add ${deps} --dev`);
+  }
+  else {
+    console.error('yarn init');
+    console.error(`yarn add ${deps} --dev`);
+  }
+  process.exit(1);
+}

--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -10,7 +10,6 @@ includes:
   javascript: ./vendor/lullabot/drainpipe/tasks/javascript.yml
 
 vars:
-  DRAINPIPE_SASS_INCLUDE_NODE_MODULES: "modern-normalize"
   DRAINPIPE_SASS: |
     web/themes/custom/mytheme/style.scss:web/themes/custom/mytheme/style.css
   DRAINPIPE_JAVASCRIPT: |
@@ -19,7 +18,10 @@ vars:
 tasks:
   assets:
     desc: "Builds assets such as CSS & JS"
-    deps: [sass:compile, javascript:compile]
+    cmds:
+      - if [ -f "yarn.lock" ]; then yarn; else npm install; fi
+      - task: javascript:compile
+      - task: sass:compile
   assets:watch:
-    desc: "Builds assets such as CSS & JS, watches for changes. Does not minify or optimise."
+    desc: "Builds assets such as CSS & JS, and watches them for changes"
     deps: [sass:watch, javascript:watch]

--- a/tasks/sass.yml
+++ b/tasks/sass.yml
@@ -8,30 +8,23 @@ tasks:
       themes/custom/<theme name>/style.css and modules/custom/<module name>/style.scss
       to modules/custom/<module name>/style.css in custom modules.
 
-      Requires sass and esbuild to be installed.
+      Includes modern-normalize, autoprefixer, and cssnano. To customise browser
+      support for autoprefixer user "browserslist" in package.json (see
+      https://github.com/postcss/autoprefixer#browsers)
 
-      usage: task sass:compile include_node_modules="modern-normalize another-node-modules-path" themes="my_custom_theme my_other_custom_theme" modules="my_module"
+      usage: task sass:compile DRAINPIPE_SASS="web/themes/custom/mytheme/style.scss:web/themes/custom/mytheme/style.css web/themes/custom/myothertheme/style.scss:web/themes/custom/myothertheme/style.css"
     cmds:
       - if [ "{{.DRAINPIPE_SASS}}" == "" ]; then echo "Nothing provided for Sass to compile"; exit 1; fi
       - |
-        if [ "{{.DRAINPIPE_SASS_INCLUDE_NODE_MODULES}}" != "" ]; then
-          INCLUDES="{{range split " " .DRAINPIPE_SASS_INCLUDE_NODE_MODULES}} -I $(yarn node -e "const path = require('path'); console.log(path.resolve(require.resolve('{{.}}'), '..', '..'));") {{end}}"
+        FILES="{{- .DRAINPIPE_SASS | catLines | trim -}}"
+        COMMAND="./node_modules/.bin/gulp"
+        if [ -f "yarn.lock" ]; then
+          COMMAND="yarn gulp"
         fi
-        FILES="{{.DRAINPIPE_SASS | catLines}}"
-
-        COMMAND="yarn sass {{.args -}} {{.CLI_ARGS -}} $INCLUDES $FILES"
-        echo "🪠 $COMMAND"
-        eval $COMMAND
-
-        {{range .DRAINPIPE_SASS | splitLines | compact}}
-          FILE="{{ . | splitList ":" | last }}"
-          COMMAND="yarn esbuild $FILE --minify --sourcemap --allow-overwrite --outfile=$FILE"
-          echo "🪠 $COMMAND"
-          eval $COMMAND
-        {{end}}
+        $COMMAND --gulpfile vendor/lullabot/drainpipe/config/gulpfile.js --cwd="./" sass{{- .args}} --files="$FILES"
   watch:
     desc: As compile, but continues running and watching for changes
     deps:
       - task: compile
         vars:
-          args: "--watch"
+          args: ":watch"


### PR DESCRIPTION
## Testing Instructions

- [ ] Install DDEV and Yarn
- [ ] Create a new test project
```
composer create-project drupal/recommended-project drainpipe-test
cd drainpipe-test
```
- [ ] Configure ddev (accepting the default options)
```
ddev config
ddev start
```
- [ ] Add this fork
```
ddev composer config repositories.lullabot/drainpipe git https://github.com/lullabot/drainpipe.git
ddev composer config minimum-stability dev
ddev composer require lullabot/drainpipe:dev-justafish/sass-autoprefixer-cssnano
```
- [ ] Install Drupal
```
ddev drush site:install minimal --yes
```
- [ ] Create a sass file
```
mkdir -p web/themes/custom/mytheme
touch web/themes/custom/mytheme/style.scss
```
- [ ] Populate `style.scss` e.g.
```
.a {
  background: blue;
  
  .b {
    color: red;
  } 
} 
```
- [ ] Create a JavaScript file
```
touch web/themes/custom/mytheme/script.js
```
- [ ] Create a yarn project
```
yarn set version berry
yarn init
```