### PR TITLE
Fix missing cd if the deploy branch doesn't exist

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -20,12 +20,12 @@ tasks:
       - if [ "" == "{{.message}}" ]; then echo "Please provide a commit message" && exit 1; fi
       - |
         TMP_DIR=$(mktemp -d)
-        git clone --depth 1 --branch {{.branch}} {{.remote}} $TMP_DIR || true
+        (git clone --depth 1 --branch {{.branch}} {{.remote}} $TMP_DIR && cd $TMP_DIR) || true
         if [[ ! -d "$TMP_DIR/.git" ]]; then
           git clone --depth 1 {{.remote}} $TMP_DIR
+          cd $TMP_DIR
           git checkout -b {{.branch}}
         fi
-        cd $TMP_DIR
         mv $TMP_DIR/.git {{.directory}}
         cd {{.directory}}
         git checkout -B {{.branch}}


### PR DESCRIPTION
If the deploy branch needs to be created, `cd` isn't called, causing the `checkout -b` to fail.