### PR TITLE
Allow opting out of pushes for local testing

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -33,6 +33,6 @@ tasks:
         git add -A
         git commit -m "{{.message}}" --allow-empty
         git push origin {{.branch}}
-        if [ "" == "{{.push}}" -o "true" == "{{.push}}" ]; then
+        if [ "{{.push}}" == "" ] || [ "{{.push}}" == "true" ]; then
           git push origin {{.branch}}
         fi


### PR DESCRIPTION
When testing locally, I didn't want to pollute the upstream repo. This allows users to not push to the repo by setting `push=false` (or any non-true string).