### PR TITLE
Make db export directories customisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,3 @@ Updates Merge Request descriptions with a markdown table of any changes detected
 in `composer.lock` using [composer-lock-diff](https://github.com/davidrjonas/composer-lock-diff).
 Requires `GITLAB_ACCESS_TOKEN` variable to be set, which is an access token with
 `api` scope.
-
-## Pantheon

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -42,9 +42,9 @@ tasks:
       DB_DIR: '{{default "/var/www/html/files/db" .DB_DIR}}'
     cmds:
       - echo "🚮 Dropping existing database"
-      - drush sql:drop --yes
+      - ./vendor/bin/drush sql:drop --yes
       - echo "📰 Importing database"
-      - drush sql:query --file=$DB_DIR/private/db.sql.gz
+      - ./vendor/bin/drush sql:query --file=$DB_DIR/private/db.sql.gz
       - defer: rm -f $DB_DIR/db.sql
   export-db:
     desc: "Exports a database fetches with a *:fetch-db command"
@@ -52,7 +52,7 @@ tasks:
       DB_DIR: '{{default "/var/www/html/files/db" .DB_DIR}}'
     cmds:
       - echo "➡ Exporting database"
-      - drush sql:dump --result-file=$DB_DIR/db.sql.gz
+      - ./vendor/bin/drush sql:dump --result-file=$DB_DIR/db.sql.gz
   update:
     desc: Run Drupal update tasks after deploying new code
     cmds:

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -44,7 +44,7 @@ tasks:
       - echo "🚮 Dropping existing database"
       - ./vendor/bin/drush sql:drop --yes
       - echo "📰 Importing database"
-      - ./vendor/bin/drush sql:query --file=$DB_DIR/private/db.sql.gz
+      - ./vendor/bin/drush sql:query --file=$DB_DIR/db.sql.gz
       - defer: rm -f $DB_DIR/db.sql
   export-db:
     desc: "Exports a database fetches with a *:fetch-db command"

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -38,16 +38,21 @@ tasks:
       - ./vendor/bin/drush --yes site:install --existing-config
   import-db:
     desc: "Imports a database fetched with a *:fetch-db command"
+    env:
+      DB_DIR: '{{default "/var/www/html/files/db" .DB_DIR}}'
     cmds:
       - echo "🚮 Dropping existing database"
       - drush sql:drop --yes
       - echo "📰 Importing database"
-      - drush sql:query --file=/var/www/html/files/private/db.sql.gz
-      - defer: rm -f /var/www/html/files/private/db.sql
-      - echo "🧹 Sanitising database"
-      - drush sql:sanitize --whitelist-fields=field_user_bio,user_picture --yes
+      - drush sql:query --file=$DB_DIR/private/db.sql.gz
+      - defer: rm -f $DB_DIR/db.sql
+  export-db:
+    desc: "Exports a database fetches with a *:fetch-db command"
+    env:
+      DB_DIR: '{{default "/var/www/html/files/db" .DB_DIR}}'
+    cmds:
       - echo "➡ Exporting database"
-      - drush sql:dump --result-file=/var/www/html/files/private/db.sql.gz
+      - drush sql:dump --result-file=$DB_DIR/db.sql.gz
   update:
     desc: Run Drupal update tasks after deploying new code
     cmds:

--- a/tasks/pantheon.yml
+++ b/tasks/pantheon.yml
@@ -3,10 +3,12 @@ version: '3'
 tasks:
   fetch-db:
     desc: "Fetches a database from Pantheon"
+    env:
+      DB_DIR: '{{default "/var/www/html/files/db" .DB_DIR}}'
     cmds:
-      - rm -f /var/www/html/files/private/db.sql.gz /var/www/html/files/private/db.sql
+      - rm -f $DB_DIR/db.sql.gz $DB_DIR/db.sql
       - if [ -z "$PANTHEON_TOKEN" ]; then echo "PANTHEON_TOKEN is empty, please add it to your .env file"; exit 1; fi
       - echo "⚡ Authorising with Pantheon"
       - terminus auth:login --machine-token="${PANTHEON_TOKEN}"
       - echo "⚡ Fetching database from Pantheon"
-      - terminus backup:get {{.PANTHEON_SITE_ID}}.live --element=db --to=/var/www/html/files/private/db.sql.gz
+      - terminus backup:get {{.PANTHEON_SITE_ID}}.live --element=db --to=$DB_DIR/db.sql.gz


### PR DESCRIPTION
Allows it to be overridden like so:
```
cmds:
      - task: drupal:import-db
        vars: {DB_DIR: "/var/www/html/files/private"}
```