### PR TITLE
Pantheon GitHub Actions: Add a Clone Environment command

### DIFF
--- a/scaffold/github/actions/pantheon/clone-env/action.yml
+++ b/scaffold/github/actions/pantheon/clone-env/action.yml
@@ -1,0 +1,40 @@
+name: "Clone Environment"
+description: "Clones a Pantheon Environment to another site"
+inputs:
+  source-site-name:
+    description: "Source site name"
+    required: true
+  source-environment:
+    description: "Source environment i.e. dev, test, or live"
+    required: true
+  target-site-name:
+    description: "Target site name"
+    required: true
+  target-environment:
+    description: "Target environment i.e. dev, test, or live"
+    required: true
+  terminus-token:
+    description: "Pantheon Terminus Token"
+    required: true
+runs:
+  using: "composite"
+  steps:
+      - name: Clone Environment
+        run: |
+          source .github/actions/drainpipe/set-env/bash_aliases
+          drainpipe_exec "terminus auth:login --machine-token=\"${{ inputs.terminus-token }}\""
+          if [ "${{ inputs.source-site-name }}" == "${{ inputs.target-site-name }}" ]; then
+            drainpipe_exec "terminus env:clone-content ${{ inputs.source-site-name }}.${{ inputs.source-environment }} ${{ inputs.target-environment }}"
+          else
+            TARGET_SITE_ID=$(drainpipe_exec "terminus site:lookup ${{ inputs.target-site-name }}")
+            drainpipe_exec "terminus -y env:wipe ${{ inputs.target-site-name }}.${{ inputs.target-environment }}"
+            DATABASE_URL=$(drainpipe_exec "terminus backup:get ${{ inputs.source-site-name }}.${{ inputs.source-environment }} --element=database")
+            # Can't pass the URL on the command line directly because it's got weird characters
+            echo $DATABASE_URL > db.env
+            drainpipe_exec "terminus -y import:database ${{ inputs.target-site-name }}.${{ inputs.target-environment }} \"\$(cat db.env)\""
+            rm db.env
+            curl -o files.tar.gz $(drainpipe_exec "terminus backup:get ${{ inputs.source-site-name }}.${{ inputs.source-environment }} --element=files")
+            tar -xf files.tar.gz
+            drainpipe_exec "rsync -rLvz --size-only --checksum --ipv4 --progress -e 'ssh -p 2222' ./files_${{ inputs.source-environment }}/. --temp-dir=~/tmp/ ${{ inputs.target-environment }}.$TARGET_SITE_ID@appserver.${{ inputs.target-environment }}.$TARGET_SITE_ID.drush.in:files"
+          fi
+        shell: bash

--- a/scaffold/github/actions/pantheon/push/action.yml
+++ b/scaffold/github/actions/pantheon/push/action.yml
@@ -19,8 +19,8 @@ runs:
     - name: Push to Pantheon
       run: |
         source .github/actions/drainpipe/set-env/bash_aliases
-        SITE_ID=$(drainpipe_exec "terminus site:lookup ${{ inputs.site-name }}")
         ddev exec terminus auth:login --machine-token="${{ inputs.terminus-token }}"
+        SITE_ID=$(drainpipe_exec "terminus site:lookup ${{ inputs.site-name }}")
         if [ "${{ inputs.branch }}" == "master" ]; then
           drainpipe_exec "terminus connection:set ${{ inputs.site-name }}.dev git --yes"
         else

--- a/scaffold/github/actions/pantheon/push/action.yml
+++ b/scaffold/github/actions/pantheon/push/action.yml
@@ -7,9 +7,6 @@ inputs:
   site-name:
     description: "Pantheon site machine name"
     required: true
-  site-id:
-    description: "Pantheon site UUID"
-    required: true
   branch:
     description: "Which branch to push to"
     required: true
@@ -22,11 +19,12 @@ runs:
     - name: Push to Pantheon
       run: |
         source .github/actions/drainpipe/set-env/bash_aliases
+        SITE_ID=$(drainpipe_exec "terminus site:lookup ${{ inputs.site-name }}")
         ddev exec terminus auth:login --machine-token="${{ inputs.terminus-token }}"
         if [ "${{ inputs.branch }}" == "master" ]; then
           drainpipe_exec "terminus connection:set ${{ inputs.site-name }}.dev git --yes"
         else
           drainpipe_exec "terminus connection:set ${{ inputs.site-name }}.${{ inputs.branch }} git --yes"
         fi
-        drainpipe_exec "./vendor/bin/task deploy:git directory=/tmp/release branch=${{ inputs.branch }} remote=ssh://codeserver.dev.${{ inputs.site-id }}@codeserver.dev.${{ inputs.site-id }}.drush.in:2222/~/repository.git message=\"${{ inputs.commit-message }}\""
+        drainpipe_exec "./vendor/bin/task deploy:git directory=/tmp/release branch=${{ inputs.branch }} remote=ssh://codeserver.dev.$SITE_ID@codeserver.dev.$SITE_ID.drush.in:2222/~/repository.git message=\"${{ inputs.commit-message }}\""
       shell: bash

--- a/scaffold/github/actions/pantheon/review/action.yml
+++ b/scaffold/github/actions/pantheon/review/action.yml
@@ -10,9 +10,6 @@ inputs:
   site-name:
     description: "Pantheon site machine name"
     required: true
-  site-id:
-    description: "Pantheon site UUID"
-    required: true
   run-installer:
     description: "Whether or not to run the Drupal site installer. Defaults to false."
     required: false
@@ -89,8 +86,9 @@ runs:
     - name: Push to Pantheon
       run: |
         source .github/actions/drainpipe/set-env/bash_aliases
+        SITE_ID=$(drainpipe_exec "terminus site:lookup ${{ inputs.site-name }}")
         drainpipe_exec "terminus connection:set  ${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER git --yes"
-        drainpipe_exec "./vendor/bin/task deploy:git directory=/tmp/release branch=pr-$DRAINPIPE_PR_NUMBER remote=ssh://codeserver.dev.${{ inputs.site-id }}@codeserver.dev.${{ inputs.site-id }}.drush.in:2222/~/repository.git message=\"${{ inputs.commit-message }}\" site=${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER"
+        drainpipe_exec "./vendor/bin/task deploy:git directory=/tmp/release branch=pr-$DRAINPIPE_PR_NUMBER remote=ssh://codeserver.dev.$SITE_ID@codeserver.dev.$SITE_ID.drush.in:2222/~/repository.git message=\"${{ inputs.commit-message }}\" site=${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER"
       shell: bash
 
     - name: Deploy to Pantheon

--- a/scaffold/github/actions/pantheon/update/action.yml
+++ b/scaffold/github/actions/pantheon/update/action.yml
@@ -10,13 +10,20 @@ inputs:
   environment:
     description: "The environment to run the updates or install in e.g. 'test'"
     required: true
+  sleep:
+    description: "The amount of time to wait before this step is run. Useful if you've just pushed code as it takes Pantheon time to sync. Default is 30"
+    required: false
 runs:
   using: "composite"
   steps:
     - name: Update site on Pantheon
       run: |
         # Wait for Pantheon to sync
-        sleep 30
+        if [ "${{ inputs.sleep }}" != "" ]; then
+          sleep ${{ inputs.sleep }}
+        else
+          sleep 30
+        fi
         source .github/actions/drainpipe/set-env/bash_aliases
         drainpipe_exec "terminus aliases --only ${{ inputs.site-name }} --yes"
         if [ "${{ inputs.run-installer }}" == "true" ]; then

--- a/scaffold/github/workflows/PantheonReviewApps.yml
+++ b/scaffold/github/workflows/PantheonReviewApps.yml
@@ -68,5 +68,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terminus-token: ${{ secrets.PANTHEON_TERMINUS_TOKEN }}
           site-name: [site-name]
-          site-id: [site-id]
           commit-message: ${{ github.event.head_commit.message }}

--- a/scaffold/github/workflows/PantheonReviewAppsDDEV.yml
+++ b/scaffold/github/workflows/PantheonReviewAppsDDEV.yml
@@ -48,5 +48,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terminus-token: ${{ secrets.PANTHEON_TERMINUS_TOKEN }}
           site-name: [site-name]
-          site-id: [site-id]
           commit-message: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
also removes the need to provide a site-id as this can be fetched via Terminus