### PR TITLE
Allow DDEV version to be customised

### DIFF
--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -1,0 +1,33 @@
+name: "Test GitHub Actions"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  Drainpipe-Deploy-Pantheon-Multidev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare Drupal
+        run: |
+          cd ../
+          mkdir drupal
+          cd drupal
+          cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/composer.json .
+          cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/Taskfile.yml .
+
+      - uses: ./scaffold/github/actions/drainpipe/set-env
+
+      - name: Install and Start DDEV
+        uses: ./scaffold/github/actions/drainpipe/ddev
+
+      - name: Build Project
+        run: |
+          ddev composer install
+          ddev task build

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -22,10 +22,10 @@ jobs:
           cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/composer.json .
           cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/Taskfile.yml .
 
-      - uses: ./scaffold/github/actions/drainpipe/set-env
+      - uses: ./scaffold/github/actions/common/set-env
 
       - name: Install and Start DDEV
-        uses: ./scaffold/github/actions/drainpipe/ddev
+        uses: ./scaffold/github/actions/common/ddev
 
       - name: Build Project
         run: |

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -28,4 +28,3 @@ jobs:
       - name: Build Project
         run: |
           ddev composer install
-          ddev task build

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -16,11 +16,9 @@ jobs:
 
       - name: Prepare Drupal
         run: |
-          cd ../
-          mkdir drupal
-          cd drupal
-          cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/composer.json .
-          cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/Taskfile.yml .
+          mv ${GITHUB_WORKSPACE}/tests/fixtures/drainpipe-test-github-actions/composer.json .
+          mv ${GITHUB_WORKSPACE}/tests/fixtures/drainpipe-test-github-actions/Taskfile.yml .
+          mv ${GITHUB_WORKSPACE}/tests/fixtures/drainpipe-test-github-actions/.ddev .
 
       - uses: ./scaffold/github/actions/common/set-env
 

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Drainpipe-Deploy-Pantheon-Multidev:
+  Test-GitHub-Actions:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -16,6 +16,9 @@ inputs:
   composer-cache-dir:
     description: "Composer cache directory, relative to the project workspace. Set to false to disable."
     required: false
+  version:
+    description: "Override the DDEV version .e.g. '1.19.0'"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -36,7 +39,14 @@ runs:
         fi
         chmod 700 .ddev/homeadditions/.ssh
 
-        curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v1.19.0-rc4
+        # Download and run the DDEV installer
+        curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh
+          bash install_ddev.sh v1.19.0
+        if [ "{{ inputs.version }}" != "" ]; then
+        else
+          bash install_ddev.sh v{{  inputs.version }}
+        fi
+        rm install_ddev.sh
         ddev config global --instrumentation-opt-in=false --omit-containers=dba,ddev-ssh-agent
 
         if [ "${{ inputs.composer-cache-dir }}" != "false" ]; then
@@ -45,7 +55,8 @@ runs:
           if [ "${{ inputs.composer-cache-dir }}" != "" ]; then
             CACHE_DIR="${{ inputs.composer-cache-dir }}"
           fi
-          ddev config --web-environment="COMPOSER_CACHE_DIR=/var/www/html/$CACHE_DIR"
+          # Composer cache disabled until https://github.com/drud/ddev/pull/3697 is released
+          #ddev config --web-environment-add="COMPOSER_CACHE_DIR=/var/www/html/$CACHE_DIR"
         fi
 
         ddev start

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -43,7 +43,7 @@ runs:
         if [ "${{ inputs.version }}" != "" ]; then
           curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v${{ inputs.version }}
         else
-          curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh
+          curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v1.19.0
         fi
         rm -f install_ddev.sh
 

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -41,7 +41,6 @@ runs:
 
         # Download and run the DDEV installer
         if [ "{{ inputs.version }}" != "" ]; then
-          bash install_ddev.sh v{{ inputs.version }}
           curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v{{ inputs.version }}
         else
           curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -41,13 +41,13 @@ runs:
 
         # Download and run the DDEV installer
         curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh
-          bash install_ddev.sh v1.19.0
         if [ "{{ inputs.version }}" != "" ]; then
-          bash install_ddev.sh v{{  inputs.version }}
+          bash install_ddev.sh v{{ inputs.version }}
         else
           bash install_ddev.sh v1.19.0
         fi
         rm install_ddev.sh
+
         ddev config global --instrumentation-opt-in=false --omit-containers=dba,ddev-ssh-agent
 
         if [ "${{ inputs.composer-cache-dir }}" != "false" ]; then

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -40,13 +40,13 @@ runs:
         chmod 700 .ddev/homeadditions/.ssh
 
         # Download and run the DDEV installer
-        curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh
         if [ "{{ inputs.version }}" != "" ]; then
           bash install_ddev.sh v{{ inputs.version }}
+          curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v{{ inputs.version }}
         else
-          bash install_ddev.sh v1.19.0
+          curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh
         fi
-        rm install_ddev.sh
+        rm -f install_ddev.sh
 
         ddev config global --instrumentation-opt-in=false --omit-containers=dba,ddev-ssh-agent
 
@@ -57,7 +57,7 @@ runs:
             CACHE_DIR="${{ inputs.composer-cache-dir }}"
           fi
           # Composer cache disabled until https://github.com/drud/ddev/pull/3697 is released
-          #ddev config --web-environment-add="COMPOSER_CACHE_DIR=/var/www/html/$CACHE_DIR"
+          # ddev config --web-environment-add="COMPOSER_CACHE_DIR=/var/www/html/$CACHE_DIR"
         fi
 
         ddev start

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -40,8 +40,8 @@ runs:
         chmod 700 .ddev/homeadditions/.ssh
 
         # Download and run the DDEV installer
-        if [ "{{ inputs.version }}" != "" ]; then
-          curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v{{ inputs.version }}
+        if [ "${{ inputs.version }}" != "" ]; then
+          curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh v${{ inputs.version }}
         else
           curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh
         fi

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -43,8 +43,9 @@ runs:
         curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh
           bash install_ddev.sh v1.19.0
         if [ "{{ inputs.version }}" != "" ]; then
-        else
           bash install_ddev.sh v{{  inputs.version }}
+        else
+          bash install_ddev.sh v1.19.0
         fi
         rm install_ddev.sh
         ddev config global --instrumentation-opt-in=false --omit-containers=dba,ddev-ssh-agent

--- a/tests/fixtures/drainpipe-test-github-actions/.ddev/config.yaml
+++ b/tests/fixtures/drainpipe-test-github-actions/.ddev/config.yaml
@@ -1,0 +1,19 @@
+name: drupal
+type: drupal9
+docroot: web
+php_version: "8.0"
+webserver_type: nginx-fpm
+router_http_port: "80"
+router_https_port: "443"
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+database:
+  type: mariadb
+  version: "10.3"
+nfs_mount_enabled: false
+mutagen_enabled: false
+use_dns_when_possible: true
+composer_version: "2"
+web_environment: []
+nodejs_version: "16"

--- a/tests/fixtures/drainpipe-test-github-actions/Taskfile.yml
+++ b/tests/fixtures/drainpipe-test-github-actions/Taskfile.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+dotenv: ['.env']
+
+includes:
+  drupal: ./vendor/lullabot/drainpipe/tasks/drupal.yml
+  snapshot: ./vendor/lullabot/drainpipe/tasks/snapshot.yml
+
+tasks:
+  build:
+    desc: "Production composer install of the project"
+    deps: [drupal:composer:production]
+    cmds:
+      - if [ ! -f "web/index.php" ]; then exit 1; fi
+      - if [ -f "vendor/lullabot/drainpipe-dev/composer.json" ]; then exit 1; fi

--- a/tests/fixtures/drainpipe-test-github-actions/composer.json
+++ b/tests/fixtures/drainpipe-test-github-actions/composer.json
@@ -1,0 +1,93 @@
+{
+  "name": "drupal/recommended-project",
+  "description": "Project template for Drupal 9 projects with a relocated document root",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "homepage": "https://www.drupal.org/project/drupal",
+  "support": {
+    "docs": "https://www.drupal.org/docs/user_guide/en/index.html",
+    "chat": "https://www.drupal.org/node/314178"
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://packages.drupal.org/8"
+    }
+  ],
+  "require": {
+    "composer/installers": "^1.9",
+    "drupal/core-composer-scaffold": "^9.3",
+    "drupal/core-project-message": "^9.3",
+    "drupal/core-recommended": "^9.3"
+  },
+  "conflict": {
+    "drupal/drupal": "*"
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true,
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/installers": true,
+      "drupal/core-composer-scaffold": true,
+      "drupal/core-project-message": true
+    }
+  },
+  "extra": {
+    "drupal-scaffold": {
+      "locations": {
+        "web-root": "web/"
+      }
+    },
+    "installer-paths": {
+      "web/core": [
+        "type:drupal-core"
+      ],
+      "web/libraries/{$name}": [
+        "type:drupal-library"
+      ],
+      "web/modules/contrib/{$name}": [
+        "type:drupal-module"
+      ],
+      "web/profiles/contrib/{$name}": [
+        "type:drupal-profile"
+      ],
+      "web/themes/contrib/{$name}": [
+        "type:drupal-theme"
+      ],
+      "drush/Commands/contrib/{$name}": [
+        "type:drupal-drush"
+      ],
+      "web/modules/custom/{$name}": [
+        "type:drupal-custom-module"
+      ],
+      "web/profiles/custom/{$name}": [
+        "type:drupal-custom-profile"
+      ],
+      "web/themes/custom/{$name}": [
+        "type:drupal-custom-theme"
+      ]
+    },
+    "drupal-core-project-message": {
+      "include-keys": [
+        "homepage",
+        "support"
+      ],
+      "post-create-project-cmd-message": [
+        "<bg=blue;fg=white>                                                         </>",
+        "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+        "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
+        "<bg=blue;fg=white>                                                         </>",
+        "",
+        "<bg=yellow;fg=black>Next steps</>:",
+        "  * Install the site: https://www.drupal.org/docs/8/install",
+        "  * Read the user guide: https://www.drupal.org/docs/user_guide/en/index.html",
+        "  * Get support: https://www.drupal.org/support",
+        "  * Get involved with the Drupal community:",
+        "      https://www.drupal.org/getting-involved",
+        "  * Remove the plugin that prints this message:",
+        "      composer remove drupal/core-project-message"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This also disables the composer cache until https://github.com/drud/ddev/pull/3697 is released as this command is breaking setups which are using existing environment variables

Additionally adds a test for the Install DDEV GitHub Action