### PR TITLE
Force the Javascript target definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Drainpipe provides tasks to automate Sass & JavaScript compilation.
 
 To enable this, first define the project variables `DRAINPIPE_SASS` and/or
 `DRAINPIPE_JAVASCRIPT` in `Taskfile.yml`.
+You can define several entries, one per line.
 
 Then define the task:
 ```
@@ -90,6 +91,12 @@ It includes SASS Glob to use glob imports to define a whole directory:
 // Base
 @use "sass/base/**/*";
 ```
+
+#### JS
+
+Source and target need to have the same basedir (web or docroot) due to being
+unable to provide separate entryNames.
+See https://github.com/evanw/esbuild/issues/224
 
 ## Validation
 

--- a/metapackages/javascript/esbuild.js
+++ b/metapackages/javascript/esbuild.js
@@ -65,6 +65,7 @@ if (uniqueFileExtension.length !== 1) {
       plugins,
       entryPoints: scripts.map(script => script.split(':')[0]),
       outdir: uniqueBaseDir[0],
+      outbase: uniqueBaseDir[0],
       entryNames: `[dir]/[name].${uniqueFileExtension[0]}`,
       bundle: true,
       sourcemap: true,


### PR DESCRIPTION
## Problem
While trying to define the JS assets in a new theme I found out that setting the variable `DRAINPIPE_JAVASCRIPT` in `Taskfile.yml` wasn't working properly: whatever I set in there it'd export it in another directory right below `docroot`.

I set:
```
DRAINPIPE_JAVASCRIPT: |
    docroot/themes/custom/my_theme/src/script.js:docroot/themes/custom/my_theme/src/script.min.js
```

And instead of exporting it into `docroot/themes/custom/my_theme/src/script.min.js`, it was creating the files into `docroot`, ignoring the target path.

## Proposed solution
@hawkeyetwolf helped me coming up with this possible solution, forcing the definition of the `outbase` value, and now the source path set is being used for the target too.


But while reading the comments about the [limitation to provide separate entryNames](https://github.com/evanw/esbuild/issues/224), wouldn't it be less confusing to just provide an entry value for any JS on the `Taskfile.yml` and use that to build both for the source and the value path?

@justafish what do you think? Does the changes makes sense? Is it enough, or should we try to improve something else?

