### PR TITLE
Enable the composer cache directory for GitHub Actions

### DIFF
--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -56,8 +56,7 @@ runs:
           if [ "${{ inputs.composer-cache-dir }}" != "" ]; then
             CACHE_DIR="${{ inputs.composer-cache-dir }}"
           fi
-          # Composer cache disabled until https://github.com/drud/ddev/pull/3697 is released
-          # ddev config --web-environment-add="COMPOSER_CACHE_DIR=/var/www/html/$CACHE_DIR"
+          ddev config --web-environment-add="COMPOSER_CACHE_DIR=/var/www/html/$CACHE_DIR"
         fi
 
         ddev start


### PR DESCRIPTION
Available as of 1.19.2 of DDEV https://github.com/drud/ddev/releases/tag/v1.19.2