### PR TITLE
Support Terminus plugins in Github and Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,4 @@ Requires `GITLAB_ACCESS_TOKEN` variable to be set, which is an access token with
   - `PANTHEON_TERMINUS_TOKEN` See https://pantheon.io/docs/terminus/install#machine-token
   - `SSH_PRIVATE_KEY` A private key of a user which can push to Pantheon
   - `SSH_KNOWN_HOSTS` The result of running `ssh-keyscan -H codeserver.dev.$PANTHEON_SITE_ID.drush.in`
+  - `TERMINUS_PLUGINS` Comma-separated list of Terminus plugins to be available (optional)

--- a/scaffold/github/actions/pantheon/setup-terminus/action.yml
+++ b/scaffold/github/actions/pantheon/setup-terminus/action.yml
@@ -4,6 +4,9 @@ inputs:
   pantheon-token:
     description: "Pantheon Terminus Token"
     required: true
+  terminus-plugins:
+    description: "Terminus plugins"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -13,6 +16,6 @@ runs:
         curl -L https://github.com/pantheon-systems/terminus/releases/download/3.0.7/terminus.phar --output ~/terminus/terminus
         chmod +x ~/terminus/terminus
         ln -s ~/terminus/terminus /usr/local/bin/terminus
-        terminus self:plugin:install pantheon-systems/terminus-secrets-plugin
+        echo "${{ inputs.terminus-plugins }}" | while read -d, plugin || [[ -n $plugin ]]; do terminus self:plugin:install $plugin; done
         terminus auth:login --machine-token="${{ inputs.pantheon-token }}"
       shell: bash

--- a/scaffold/github/actions/pantheon/setup-terminus/action.yml
+++ b/scaffold/github/actions/pantheon/setup-terminus/action.yml
@@ -13,5 +13,6 @@ runs:
         curl -L https://github.com/pantheon-systems/terminus/releases/download/3.0.7/terminus.phar --output ~/terminus/terminus
         chmod +x ~/terminus/terminus
         ln -s ~/terminus/terminus /usr/local/bin/terminus
+        terminus self:plugin:install pantheon-systems/terminus-secrets-plugin
         terminus auth:login --machine-token="${{ inputs.pantheon-token }}"
       shell: bash

--- a/scaffold/github/workflows/PantheonReviewApps.yml
+++ b/scaffold/github/workflows/PantheonReviewApps.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: ./github/actions/drainpipe/pantheon/setup-terminus
         with:
           pantheon-token: ${{ secrets.PANTHEON_TERMINUS_TOKEN }}
+          terminus-plugins: ${{ secrets.TERMINUS_PLUGINS }}
 
       - uses: php-actions/composer@v6
 

--- a/scaffold/gitlab/Pantheon.gitlab-ci.yml
+++ b/scaffold/gitlab/Pantheon.gitlab-ci.yml
@@ -7,4 +7,5 @@
     - curl -L https://github.com/pantheon-systems/terminus/releases/download/3.0.7/terminus.phar --output ~/terminus/terminus
     - chmod +x ~/terminus/terminus
     - ln -s ~/terminus/terminus /usr/local/bin/terminus
+    - terminus self:plugin:install pantheon-systems/terminus-secrets-plugin
     - terminus auth:login --machine-token="$PANTHEON_TERMINUS_TOKEN"

--- a/scaffold/gitlab/Pantheon.gitlab-ci.yml
+++ b/scaffold/gitlab/Pantheon.gitlab-ci.yml
@@ -7,5 +7,5 @@
     - curl -L https://github.com/pantheon-systems/terminus/releases/download/3.0.7/terminus.phar --output ~/terminus/terminus
     - chmod +x ~/terminus/terminus
     - ln -s ~/terminus/terminus /usr/local/bin/terminus
-    - terminus self:plugin:install pantheon-systems/terminus-secrets-plugin
+    - echo "$TERMINUS_PLUGINS" | while read -d, plugin || [[ -n $plugin ]]; do terminus self:plugin:install $plugin; done
     - terminus auth:login --machine-token="$PANTHEON_TERMINUS_TOKEN"

--- a/scaffold/gitlab/gitlab-ci.example.yml
+++ b/scaffold/gitlab/gitlab-ci.example.yml
@@ -32,6 +32,9 @@ variables:
   # Only supported by GitLab Premium or self-hosted GitLab
   # Needs "api" scope. Used by Composer Lock Diff and Pantheon Multidev Cleanup.
   #GITLAB_ACCESS_TOKEN
+  #
+  # A comma-separated list of Terminus plugins to install
+  #TERMINUS_PLUGINS
 
 cache:
   key:


### PR DESCRIPTION
This PR just makes the [Terminus Secrets plugin](https://github.com/pantheon-systems/terminus-secrets-plugin) available by default when installing Drainpipe