### PR TITLE
Configure of Tugboat

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,39 @@ Requires `GITLAB_ACCESS_TOKEN` variable to be set, which is an access token with
   - `SSH_PRIVATE_KEY` A private key of a user which can push to Pantheon
   - `SSH_KNOWN_HOSTS` The result of running `ssh-keyscan -H codeserver.dev.$PANTHEON_SITE_ID.drush.in`
   - `TERMINUS_PLUGINS` Comma-separated list of Terminus plugins to be available (optional)
+
+## Tugboat Integration
+
+Add the following to `composer.json` for Tugboat helpers:
+```json
+"extra": {
+  "drainpipe": {
+    "tugboat": []
+  }
+}
+```
+
+This will import [`./.tugboat/config.example.yml`](./.tugboat/config.example.yml),
+and import [`./web/sites/default/settings.php`](./web/sites/default/settings.php).
+
+### Acquia
+```json
+"extra": {
+    "drainpipe": {
+        "gitlab": ["acquia"]
+    }
+}
+```
+This will import [`./.tugboat/tugboat.acquia-example.yml`](./.tugboat/tugboat.acquia-example.yml),
+this file includes memcached.
+
+### Pantheon
+```json
+"extra": {
+    "drainpipe": {
+        "gitlab": ["pantheon"]
+    }
+}
+```
+This will import [`./.tugboat/tugboat.pantheon-example.yml`](./.tugboat/tugboat.pantheon-example.yml),
+this file includes redis.

--- a/scaffold/tugboat/config.example.yml
+++ b/scaffold/tugboat/config.example.yml
@@ -1,0 +1,119 @@
+# This serves as a Tugboat configuration file for Drupal websites. It sets up:
+#
+# 1. PHP 8.1 with Apache as the web server.
+# 2. MariaDB 10 for the database.
+# 3. drush-launcher
+# 4. Enables the PHP opcache and required Apache extensions.
+services:
+
+  # What to call the service hosting the site.
+  php:
+    # Only allow access via https.
+    http: false
+
+    # Use PHP 8.1 with Apache
+    image: tugboatqa/php:8.1-apache-bullseye
+
+    # Set this as the default service. This does a few things
+    #   1. Clones the git repository into the service container
+    #   2. Exposes port 80 to the Tugboat HTTP proxy
+    #   3. Routes requests to the preview URL to this service
+    default: true
+
+    # Wait until the mariadb service is done building
+    depends:
+      - mariadb
+
+    # A set of commands to run while building this service
+    commands:
+
+      # Commands that set up the basic preview infrastructure
+      init: |
+        set -eux
+        echo "Initializing..."
+        # Install prerequisite packages
+        apt-get update
+        apt-get install -y mariadb-client libldap2-dev
+
+        # Install drush-launcher
+        wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.10.1/drush.phar
+        chmod +x /usr/local/bin/drush
+
+        # Link the document root to the expected path. Tugboat uses /docroot
+        # by default. So, if Drupal is located at any other path in your git
+        # repository, change that here. This example links /web to the docroot
+        [ -d "${DOCROOT}" ] || ln -snf "${TUGBOAT_ROOT}/web" "${DOCROOT}"
+
+        docker-php-ext-install opcache
+        a2enmod headers rewrite
+
+        # WebP
+        apt-get install -y libwebp-dev libwebp6 webp libmagickwand-dev
+        docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp
+        docker-php-ext-install gd
+
+        # Configure GD
+        apt-get update && apt-get install -y libpng-dev libjpeg-dev libfreetype6-dev
+        docker-php-ext-configure gd --with-jpeg --with-freetype && docker-php-ext-install gd
+
+        # Install drush-launcher, if desired.
+        wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
+        chmod +x /usr/local/bin/drush
+
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update: |
+        set -eux
+        echo "Updating..."
+
+        # We intentionally do not set up syncing of static assets, as we have
+        # decided to always use Stage File Proxy:
+        # https://architecture.lullabot.com/adr/20210729-stage-file-proxy/
+
+        # Set up permissions for the files directories.
+        chgrp -R www-data "${TUGBOAT_ROOT}/web/sites/default/files"
+        chmod -R g+w "${TUGBOAT_ROOT}/web/sites/default/files"
+        chmod 2775 "${TUGBOAT_ROOT}/web/sites/default/files"
+
+        composer install
+
+        # Install Drupal using the standard profile.
+        vendor/bin/task drupal:install
+
+        # To use an existing site, add the appropriate environment variables
+        # as document at <LINK> and instead run:
+        # vendor/bin/task <provider>:fetch-db
+        # vendor/bin/task drupal:import-db
+
+        # Install
+        echo "Install drush"
+        drush site:install
+
+      # Commands that build the site. This is where you would add things
+      # like feature reverts or any other drush commands required to
+      # set up or configure the site. When a preview is built from a
+      # base preview, the build workflow starts here, skipping the init
+      # and update steps, because the results of those are inherited
+      # from the base preview.
+      build: |
+        set -eux
+        vendor/bin/task drupal:update
+        vendor/bin/drush user:login
+
+  # What to call the service hosting MySQL. This name also acts as the
+  # hostname to access the service by from the php service.
+  mariadb:
+
+    image: tugboatqa/mariadb:10
+
+    # A set of commands to run while building this service
+    commands:
+
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update:
+        - echo "Nothing to do as we import databases from the Drupal service."

--- a/scaffold/tugboat/settings.tugboat.php
+++ b/scaffold/tugboat/settings.tugboat.php
@@ -1,0 +1,14 @@
+<?php
+
+if (getenv('TUGBOAT_REPO') !== FALSE) {
+  $databases['default']['default'] = [
+    'database' => 'tugboat',
+    'username' => 'tugboat',
+    'password' => 'tugboat',
+    'prefix' => '',
+    'host' => 'mariadb',
+    'port' => '3306',
+    'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+    'driver' => 'mysql',
+  ];
+}

--- a/scaffold/tugboat/tugboat.acquia-example.yml
+++ b/scaffold/tugboat/tugboat.acquia-example.yml
@@ -1,0 +1,115 @@
+# This serves as a Tugboat configuration file for Drupal websites. It sets up:
+#
+# 1. PHP 8.1 with Apache as the web server.
+# 2. MariaDB 10 for the database.
+# 3. drush-launcher
+# 4. Enables the PHP opcache and required Apache extensions.
+services:
+
+  # What to call the service hosting the site.
+  php:
+    # Only allow access via https.
+    http: false
+
+    # Use PHP 8.1 with Apache
+    image: tugboatqa/php:8.1-apache-bullseye
+
+    # Set this as the default service. This does a few things
+    #   1. Clones the git repository into the service container
+    #   2. Exposes port 80 to the Tugboat HTTP proxy
+    #   3. Routes requests to the preview URL to this service
+    default: true
+
+    # Wait until the mariadb service is done building
+    depends:
+      - mariadb
+
+    # A set of commands to run while building this service
+    commands:
+
+      # Commands that set up the basic preview infrastructure
+      init: |
+        set -eux
+        echo "Initializing..."
+        # Install prerequisite packages
+        apt-get update
+        apt-get install -y mariadb-client libldap2-dev
+
+        # Install drush-launcher
+        wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.10.1/drush.phar
+        chmod +x /usr/local/bin/drush
+
+        # Link the document root to the expected path. Tugboat uses /docroot
+        # by default. So, if Drupal is located at any other path in your git
+        # repository, change that here. This example links /web to the docroot
+        [ -d "${DOCROOT}" ] || ln -snf "${TUGBOAT_ROOT}/web" "${DOCROOT}"
+
+        docker-php-ext-install opcache
+        a2enmod headers rewrite
+
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update: |
+        set -eux
+        echo "Updating..."
+
+        # We intentionally do not set up syncing of static assets, as we have
+        # decided to always use Stage File Proxy:
+        # https://architecture.lullabot.com/adr/20210729-stage-file-proxy/
+
+        # Set up permissions for the files directories.
+        chgrp -R www-data "${DOCROOT}/sites/default/files"
+        chmod -R g+w "${DOCROOT}/sites/default/files"
+        chmod 2775 "${DOCROOT}/sites/default/files"
+
+        composer install
+
+        # Install Drupal using the standard profile.
+        vendor/bin/task drupal:install
+
+        # To use an existing site, add the appropriate environment variables
+        # as document at <LINK> and instead run:
+        # vendor/bin/task <provider>:fetch-db
+        # vendor/bin/task drupal:import-db
+
+      # Commands that build the site. This is where you would add things
+      # like feature reverts or any other drush commands required to
+      # set up or configure the site. When a preview is built from a
+      # base preview, the build workflow starts here, skipping the init
+      # and update steps, because the results of those are inherited
+      # from the base preview.
+      build: |
+        set -eux
+        vendor/bin/task drupal:update
+        vendor/bin/drush user:login
+
+  # What to call the service hosting MySQL. This name also acts as the
+  # hostname to access the service by from the php service.
+  mariadb:
+
+    image: tugboatqa/mariadb:10
+
+    # A set of commands to run while building this service
+    commands:
+
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update:
+        - echo "Nothing to do as we import databases from the Drupal service."
+
+  memcached:
+
+    image: tugboatqa/memcached:1
+
+#    commands:
+#
+#      update: |
+#
+#        if [[ "tugboatqa/memcached:1" == "NULL" ]]; then
+#          echo -e "FATAL ERROR: Not installed"
+#          exit 1
+#        fi

--- a/scaffold/tugboat/tugboat.pantheon-example.yml
+++ b/scaffold/tugboat/tugboat.pantheon-example.yml
@@ -1,0 +1,104 @@
+# This serves as a Tugboat configuration file for Drupal websites. It sets up:
+#
+# 1. PHP 8.1 with Apache as the web server.
+# 2. MariaDB 10 for the database.
+# 3. drush-launcher
+# 4. Enables the PHP opcache and required Apache extensions.
+services:
+
+  # What to call the service hosting the site.
+  php:
+    # Only allow access via https.
+    http: false
+
+    # Use PHP 8.1 with Apache
+    image: tugboatqa/php:8.1-apache-bullseye
+
+    # Set this as the default service. This does a few things
+    #   1. Clones the git repository into the service container
+    #   2. Exposes port 80 to the Tugboat HTTP proxy
+    #   3. Routes requests to the preview URL to this service
+    default: true
+
+    # Wait until the mariadb service is done building
+    depends:
+      - mariadb
+
+    # A set of commands to run while building this service
+    commands:
+
+      # Commands that set up the basic preview infrastructure
+      init: |
+        set -eux
+        echo "Initializing..."
+        # Install prerequisite packages
+        apt-get update
+        apt-get install -y mariadb-client libldap2-dev
+        # Install drush-launcher
+        wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.10.1/drush.phar
+        chmod +x /usr/local/bin/drush
+        # Link the document root to the expected path. Tugboat uses /docroot
+        # by default. So, if Drupal is located at any other path in your git
+        # repository, change that here. This example links /web to the docroot
+        [ -d "${DOCROOT}" ] || ln -snf "${TUGBOAT_ROOT}/web" "${DOCROOT}"
+        docker-php-ext-install opcache
+        a2enmod headers rewrite
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update: |
+        set -eux
+        echo "Updating..."
+        # We intentionally do not set up syncing of static assets, as we have
+        # decided to always use Stage File Proxy:
+        # https://architecture.lullabot.com/adr/20210729-stage-file-proxy/
+        # Set up permissions for the files directories.
+        chgrp -R www-data "${DOCROOT}/sites/default/files"
+        chmod -R g+w "${DOCROOT}/sites/default/files"
+        chmod 2775 "${DOCROOT}/sites/default/files"
+        composer install
+        # Install Drupal using the standard profile.
+        vendor/bin/task drupal:install
+        # To use an existing site, add the appropriate environment variables
+        # as document at <LINK> and instead run:
+        # vendor/bin/task <provider>:fetch-db
+        # vendor/bin/task drupal:import-db
+      # Commands that build the site. This is where you would add things
+      # like feature reverts or any other drush commands required to
+      # set up or configure the site. When a preview is built from a
+      # base preview, the build workflow starts here, skipping the init
+      # and update steps, because the results of those are inherited
+      # from the base preview.
+      build: |
+        set -eux
+        vendor/bin/task drupal:update
+        vendor/bin/drush user:login
+  # What to call the service hosting MySQL. This name also acts as the
+  # hostname to access the service by from the php service.
+  mariadb:
+
+    image: tugboatqa/mariadb:10
+
+    # A set of commands to run while building this service
+    commands:
+
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update:
+        - echo "Nothing to do as we import databases from the Drupal service."
+
+  redis:
+
+    image: tugboatqa/redis:7
+
+#    commands:
+#
+#      update: |
+#
+#        if [[ "tugboatqa/redis:7" == "NULL" ]]; then
+#          echo -e "FATAL ERROR: Not installed"
+#          exit 1
+#        fi

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -152,7 +152,7 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             if (strpos($contents, '.task') === false) {
                 $this->io->warning(
                     sprintf(
-                    '.gitignore does not contain drainpipe ignores. Compare .gitignore in the root of your repository with %s and update as needed.',
+                        '.gitignore does not contain drainpipe ignores. Compare .gitignore in the root of your repository with %s and update as needed.',
                         $gitignorePath
                     )
                 );
@@ -161,7 +161,7 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
     }
 
     /**
-     * Install DDEV Commands.
+     *
      */
     private function installDdevCommand(): void
     {
@@ -171,12 +171,6 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             $fs = new Filesystem();
             $fs->ensureDirectoryExists('./.ddev/commands/web');
             $fs->copy($ddevCommandPath, './.ddev/commands/web/task');
-
-            # Enable .env file support via docker-composer web environment.
-            $fs->copy($vendor.'/lullabot/drainpipe/scaffold/ddev/docker-compose-.env-file.yaml', './.ddev');
-            if (!is_file('./.env')) {
-                $fs->copy($vendor.'/lullabot/drainpipe/scaffold/ddev/env', './.env');
-            }
         }
     }
 
@@ -251,6 +245,47 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
                         else {
                             $fs->copy("$scaffoldPath/github/workflows/PantheonReviewApps.yml", './.github/workflows/PantheonReviewApps.yml');
                         }
+                    }
+                }
+            }
+        }
+
+        // Tugboat
+        if (isset($this->extra['drainpipe']['tugboat']) && is_array($this->extra['drainpipe']['tugboat'])) {
+            if (!file_exists('./.tugboat/config.yml')) {
+                $fs->ensureDirectoryExists('./.tugboat');
+                $fs->copy("$scaffoldPath/tugboat/config.example.yml", './.tugboat/config.yml');
+                $this->io->write("🪠 [Drainpipe] .tugboat/config.yml installed. Please commit this file.");
+                if (!file_exists('./web/sites/default/settings.tugboat.php')) {
+                    $fs->copy("$scaffoldPath/tugboat/settings.tugboat.php", './web/sites/default/settings.tugboat.php');
+                    $this->io->write("🪠 [Drainpipe] web/sites/default/settings.tugboat.php installed. Please commit this file.");
+                    if (file_exists('./web/sites/default/settings.php')) {
+                        $include=<<<EOD
+
+include __DIR__ . "/settings.tugboat.php";
+EOD;
+
+                        file_put_contents('./web/sites/default/settings.php', $include, FILE_APPEND);
+                        $this->io->write("🪠 [Drainpipe] web/sites/default/settings.php modified to include settings.tugboat.php. Please commit this file.");
+                    }
+                    else {
+                        $this->io->write("🪠 [Drainpipe] web/sites/default/settings.php does not exist. Please include tugboat.settings.php from your settings.php files.");
+                    }
+                }
+            }
+            foreach ($this->extra['drainpipe']['tugboat'] as $provider) {
+                if ($provider === 'acquia') {
+                    if (!file_exists('./.tugboat/tugboat.acquia-example.yml')) {
+                        $fs->ensureDirectoryExists('./.tugboat');
+                        $fs->copy("$scaffoldPath/tugboat/tugboat.acquia-example.yml", './.tugboat/tugboat.acquia-example.yml');
+                        $this->io->write("🪠 [Drainpipe] .tugboat/tugboat.acquia-example.yml installed. Please commit this file.");
+                    }
+                }
+                if ($provider === 'pantheon') {
+                    if (!file_exists('./.tugboat/tugboat.pantheon-example.yml')) {
+                        $fs->ensureDirectoryExists('./.tugboat');
+                        $fs->copy("$scaffoldPath/tugboat/tugboat.pantheon-example.yml", './.tugboat/tugboat.pantheon-example.yml');
+                        $this->io->write("🪠 [Drainpipe] .tugboat/tugboat.pantheon-example.yml installed. Please commit this file.");
                     }
                 }
             }


### PR DESCRIPTION
Added a `tugboat.pantheon-example.yml` file that includes redis.

- [ ]  Go to composer.json and place:
```
"extra": {
    "drainpipe": {
        "tugboat": ["pantheon"]
    }
},
```


- [ ] run the command

Added a `tugboat.acquia-example.yml` file that includes memcache.

- [ ] Go to composer.json and place:
```
"extra": {
     "drainpipe": {
         "tugboat": ["acquia"]
     }
}
```

- [ ]  run the command

- [ ] The readme was updated where the new variables in Tugboat are mentioned

- [ ] In the `config.example.yml` file, the GD configuration was added and also about the installation of site:install 

```
apt-get update && apt-get install -y libpng-dev libjpeg-dev libfreetype6-dev
docker-php-ext-configure gd --with-jpeg --with-freetype && docker-php-ext-install gd
```

The `drush site:install` command hasn't been tested yet