### PR TITLE
Override default $DOCROOT symlink

### DIFF
--- a/scaffold/tugboat/config.example.yml
+++ b/scaffold/tugboat/config.example.yml
@@ -42,7 +42,7 @@ services:
         # Link the document root to the expected path. Tugboat uses /docroot
         # by default. So, if Drupal is located at any other path in your git
         # repository, change that here. This example links /web to the docroot
-        [ -d "${DOCROOT}" ] || ln -snf "${TUGBOAT_ROOT}/web" "${DOCROOT}"
+        ln -snf "${TUGBOAT_ROOT}/web" "${DOCROOT}"
 
         docker-php-ext-install opcache
         a2enmod headers rewrite


### PR DESCRIPTION
I'm not sure if it's new in the latest Tugboat image, but the $DOCROOT symlink already exists and points to `/var/www/html.original`. So when trying to use this config on a recent client project, I needed to remove the `[ -d ]` ("is file") shell test and overwrite the existing `$DOCROOT` symlink. 