### PR TITLE
Unignore services files that start with wildcard

### DIFF
--- a/scaffold/gitignore/common.gitignore
+++ b/scaffold/gitignore/common.gitignore
@@ -27,10 +27,12 @@ web/sites/*
 !web/sites/default
 web/sites/default/*
 !web/sites/default/settings.php
+!web/sites/default/settings.*.php
 !web/sites/default/services.yml
 !web/sites/default/*.services.yml
-!web/sites/default/settings.*.php
 !web/sites/default/files
+# Reginore default services file provided with Drupal scaffolding.
+web/sites/default/default.services.yml
 
 vendor
 

--- a/scaffold/gitignore/common.gitignore
+++ b/scaffold/gitignore/common.gitignore
@@ -28,7 +28,7 @@ web/sites/*
 web/sites/default/*
 !web/sites/default/settings.php
 !web/sites/default/services.yml
-!web/sites/default/services.*.yml
+!web/sites/default/*.services.yml
 !web/sites/default/settings.*.php
 !web/sites/default/files
 

--- a/scaffold/gitignore/common.gitignore
+++ b/scaffold/gitignore/common.gitignore
@@ -26,7 +26,6 @@ web/sites/*
 
 !web/sites/default
 web/sites/default/*
-!web/sites/default/files
 !web/sites/default/settings.php
 !web/sites/default/settings.*.php
 !web/sites/default/services.yml

--- a/scaffold/gitignore/common.gitignore
+++ b/scaffold/gitignore/common.gitignore
@@ -26,11 +26,11 @@ web/sites/*
 
 !web/sites/default
 web/sites/default/*
+!web/sites/default/files
 !web/sites/default/settings.php
 !web/sites/default/settings.*.php
 !web/sites/default/services.yml
 !web/sites/default/*.services.yml
-!web/sites/default/files
 # Reginore default services file provided with Drupal scaffolding.
 web/sites/default/default.services.yml
 


### PR DESCRIPTION
Drupal comes with `development.services.yml`, which is a different filename pattern than what's used for settings files (e.g., `settings.local.php`). 

Optionally, we could unignore _both_ patterns if folks prefer that.