### PR TITLE
Only copy the docker compose env support in if a .env file exists

### DIFF
--- a/scaffold/ddev/env
+++ b/scaffold/ddev/env
@@ -1,1 +1,0 @@
-# Environment variables.

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -173,9 +173,8 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             $fs->copy($ddevCommandPath, './.ddev/commands/web/task');
 
             # Enable .env file support via docker-composer web environment.
-            $fs->copy($vendor.'/lullabot/drainpipe/scaffold/ddev/docker-compose.env-file.yaml', './.ddev/docker-compose.env-file.yaml');
-            if (!is_file('./.env')) {
-                $fs->copy($vendor.'/lullabot/drainpipe/scaffold/ddev/env', './.env');
+            if (is_file('./.env')) {
+                $fs->copy($vendor.'/lullabot/drainpipe/scaffold/ddev/docker-compose.env-file.yaml', './.ddev/docker-compose.env-file.yaml');
             }
         }
     }


### PR DESCRIPTION
After fixing this functionality and then pulling it into an actual project it caused a lot of things to break. This modifies the scaffolder to only bring the compose file in if `.env` exists already.

See:
https://github.com/docker/compose/issues/3560
https://github.com/docker/compose/pull/3955
https://github.com/docker/compose/issues/9181
https://github.com/Lullabot/lullabot.com-d8/pull/2252/checks?sha=c015942c2e232261d91883a240048cb40726f19d