### PR TITLE
Echo string instead of executing string

### DIFF
--- a/scaffold/github/actions/pantheon/review/action.yml
+++ b/scaffold/github/actions/pantheon/review/action.yml
@@ -68,7 +68,7 @@ runs:
             done
             drainpipe_exec "terminus multidev:delete ${{ inputs.site-name }}.$MULTIDEV --delete-branch --yes"
           else
-            "Dangling Multidev environment $MULTIDEV found, no action taken."
+            echo "Dangling Multidev environment $MULTIDEV found, no action taken."
           fi
         done
       shell: bash


### PR DESCRIPTION
### Description

I was having this issue:
![image](https://user-images.githubusercontent.com/3916979/201154282-96234fef-ec1d-4a8c-a85a-669261672cbe.png)

`Multidev environment hero found, no action taken.: command not found`

Where "hero" was the name of the environment.