### PR TITLE
Fixes .env support

### DIFF
--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -49,13 +49,25 @@ jobs:
       - name: Check gitignore contains .env
         run: grep -q '.env' .gitignore
 
-      - name: Add a value to the .env file
+      - name: Test if the environment variable is available via Task
         run: |
-          echo "FOO=bar" >> .env
-          echo "  echo:" >> .env
-          echo "    cmds:" >> .env
-          echo '      - if [ "$FOO" != "bar" ]; then exit 1; fi' >> .env
-          ddev restart
+          echo "FOO=bar" >> .env.defaults
+          cp tests/fixtures/env/Taskfile-dotenv.yml Taskfile.yml
+          ddev task bar
 
       - name: Test if the environment variable is available to the DDEV web container
-        run: ddev task echo
+        run: |
+          ddev restart
+          cp tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
+          ddev exec 'if [ "$FOO" != "bar" ]; then exit 1; fi'
+
+      - name: Test overriding with .env
+        run: |
+          echo "FOO=baz" >> .env
+          cp tests/fixtures/env/Taskfile-dotenv.yml Taskfile.yml
+          ddev task baz
+          ddev restart
+          cp tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
+          ddev exec 'if [ "$FOO" != "baz" ]; then exit 1; fi'
+
+

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -49,17 +49,17 @@ jobs:
       - name: Check gitignore contains .env
         run: grep -q '.env' .gitignore
 
-      - name: Test if the environment variable is available via Task
+      - name: Test .env.defaults
         run: |
           echo "FOO=bar" >> .env.defaults
           cp drainpipe/tests/fixtures/env/Taskfile-dotenv.yml Taskfile.yml
           ddev task bar
-
-      - name: Test if the environment variable is available to the DDEV web container
-        run: |
           ddev restart
           cp drainpipe/tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
           ddev exec 'if [ "$FOO" != "bar" ]; then exit 1; fi'
+          cat composer.json | jq '."autoload-dev" = {"files": ["vendor/lullabot/drainpipe/scaffold/env/load.environment.php"]}' | tee composer.json > /dev/null
+          DRUPAL_FOO_DEFAULT=$(ddev drush php:eval "print getenv('FOO')")
+          if [ "$DRUPAL_FOO_DEFAULT" != "bar" ]; then exit 1; fi
 
       - name: Test overriding with .env
         run: |
@@ -69,5 +69,7 @@ jobs:
           ddev task baz
           cp drainpipe/tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
           ddev exec 'if [ "$FOO" != "baz" ]; then exit 1; fi'
+          DRUPAL_FOO=$(ddev drush php:eval "print getenv('FOO')")
+          if [ "$DRUPAL_FOO" != "baz" ]; then exit 1; fi
 
 

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -1,0 +1,65 @@
+name: "Test Environment Variables"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  Test-Env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create a Drupal project
+        run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+
+      - uses: actions/checkout@v3
+        with:
+          repository: lullabot/drainpipe
+          path: drainpipe
+
+      - uses: ./drainpipe/scaffold/github/actions/common/set-env
+
+      - name: Install DDEV
+        uses: ./drainpipe/scaffold/github/actions/common/ddev
+        with:
+          git-name: Drainpipe Bot
+          git-email: no-reply@example.com
+
+      - name: Setup Project
+        run: |
+          ddev config --auto
+          ddev start
+          ddev composer config extra.drupal-scaffold.gitignore true
+          ddev composer config --json extra.drupal-scaffold.allowed-packages \[\"lullabot/drainpipe\"]
+          ddev composer config --no-plugins allow-plugins.composer/installers true
+          ddev composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
+          ddev composer config --no-plugins allow-plugins.lullabot/drainpipe true
+          ddev composer config repositories.drainpipe --json "{\"type\": \"path\", \"url\": \"drainpipe\", \"options\": {\"symlink\": false}}"
+          ddev composer config minimum-stability dev
+          ddev composer require lullabot/drainpipe --with-all-dependencies
+
+      - name: Install Drupal
+        run: |
+          ddev drush site:install -y
+
+      - name: Check files are created
+        run: |
+          test -f .env
+          test -f .env.defaults
+
+      - name: Check gitignore contains .env
+        run: grep -q '.env' .gitignore
+
+      - name: Add a value to the .env file
+        run: |
+          echo "FOO=bar" >> .env
+          echo "  echo:" >> .env
+          echo "    cmds:" >> .env
+          echo "      - if [ "$FOO" != "bar" ]; then exit 1; fi >> .env
+          ddev restart
+
+      - name: Test if the environment variable is available to the DDEV web container
+        run: ddev task echo

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -52,22 +52,22 @@ jobs:
       - name: Test if the environment variable is available via Task
         run: |
           echo "FOO=bar" >> .env.defaults
-          cp tests/fixtures/env/Taskfile-dotenv.yml Taskfile.yml
+          cp drainpipe/tests/fixtures/env/Taskfile-dotenv.yml Taskfile.yml
           ddev task bar
 
       - name: Test if the environment variable is available to the DDEV web container
         run: |
           ddev restart
-          cp tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
+          cp drainpipe/tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
           ddev exec 'if [ "$FOO" != "bar" ]; then exit 1; fi'
 
       - name: Test overriding with .env
         run: |
           echo "FOO=baz" >> .env
-          cp tests/fixtures/env/Taskfile-dotenv.yml Taskfile.yml
+          cp drainpipe/tests/fixtures/env/Taskfile-dotenv.yml Taskfile.yml
           ddev task baz
           ddev restart
-          cp tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
+          cp drainpipe/tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
           ddev exec 'if [ "$FOO" != "baz" ]; then exit 1; fi'
 
 

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -63,8 +63,8 @@ jobs:
 
       - name: Test overriding with .env
         run: |
-          ddev restart
           echo "FOO=baz" >> .env
+          ddev restart
           cp drainpipe/tests/fixtures/env/Taskfile-dotenv.yml Taskfile.yml
           ddev task baz
           cp drainpipe/tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -61,9 +61,6 @@ jobs:
           cp drainpipe/tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
           ddev exec 'if [ "$FOO" != "bar" ]; then exit 1; fi'
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Test overriding with .env
         run: |
           ddev restart

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check gitignore contains .env
         run: grep -q '.env' .gitignore
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Test if the environment variable is available via Task
         run: |
           echo "FOO=bar" >> .env.defaults

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -66,10 +66,10 @@ jobs:
 
       - name: Test overriding with .env
         run: |
+          ddev restart
           echo "FOO=baz" >> .env
           cp drainpipe/tests/fixtures/env/Taskfile-dotenv.yml Taskfile.yml
           ddev task baz
-          ddev restart
           cp drainpipe/tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
           ddev exec 'if [ "$FOO" != "baz" ]; then exit 1; fi'
 

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -41,10 +41,6 @@ jobs:
           ddev composer config minimum-stability dev
           ddev composer require lullabot/drainpipe --with-all-dependencies
 
-      - name: Install Drupal
-        run: |
-          ddev drush site:install -y
-
       - name: Check files are created
         run: |
           test -f .env
@@ -58,7 +54,7 @@ jobs:
           echo "FOO=bar" >> .env
           echo "  echo:" >> .env
           echo "    cmds:" >> .env
-          echo "      - if [ "$FOO" != "bar" ]; then exit 1; fi >> .env
+          echo '      - if [ "$FOO" != "bar" ]; then exit 1; fi' >> .env
           ddev restart
 
       - name: Test if the environment variable is available to the DDEV web container

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -61,6 +61,9 @@ jobs:
           cp drainpipe/tests/fixtures/env/Taskfile-no-dotenv.yml Taskfile.yml
           ddev exec 'if [ "$FOO" != "bar" ]; then exit 1; fi'
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Test overriding with .env
         run: |
           echo "FOO=baz" >> .env

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -49,9 +49,6 @@ jobs:
       - name: Check gitignore contains .env
         run: grep -q '.env' .gitignore
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Test if the environment variable is available via Task
         run: |
           echo "FOO=bar" >> .env.defaults

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ composer create-project drupal/recommended-project drupal
 cd drupal
 ddev config
 ddev start
-ddev composer require lullabot/drainpipe
 ddev composer config extra.drupal-scaffold.gitignore true
-ddev composer config --json extra.drupal-scaffold.allowed-packages \[\"lullabot/drainpipe-dev\"]
+ddev composer config --json extra.drupal-scaffold.allowed-packages \[\"lullabot/drainpipe\", \"lullabot/drainpipe-dev\"]
+ddev composer config --json autoload-dev.files \[\"vendor/lullabot/drainpipe/scaffold/env/load.environment.php\"]
+ddev composer require lullabot/drainpipe
 ddev composer require lullabot/drainpipe-dev --dev
 # Restart is required to enable the provided Selenium containers
 ddev restart

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ ddev config
 ddev start
 ddev composer config extra.drupal-scaffold.gitignore true
 ddev composer config --json extra.drupal-scaffold.allowed-packages \[\"lullabot/drainpipe\", \"lullabot/drainpipe-dev\"]
-ddev composer config --json autoload-dev.files \[\"vendor/lullabot/drainpipe/scaffold/env/load.environment.php\"]
 ddev composer require lullabot/drainpipe
 ddev composer require lullabot/drainpipe-dev --dev
 # Restart is required to enable the provided Selenium containers

--- a/README.md
+++ b/README.md
@@ -112,14 +112,17 @@ unable to provide separate entryNames.
 See https://github.com/evanw/esbuild/issues/224
 
 ## .env support
-Drainpipe will add `.env` file support for managing environment variables locally.
+Drainpipe will add `.env` file support for managing environment variables.
 This consists of:
 - Creation of a `.env` and `.env.defaults` file
 - DDEV integration to bring the environment variables into the DDEV web container
+- Default `Taskfile.yml` contains [dotenv support](https://taskfile.dev/usage/#env-files)
+  _note: real environment variables will override these i.e. ones set in DDEV_
 - Drupal integration via [`vlucas/phpdotenv`](https://packagist.org/packages/vlucas/phpdotenv)
   To enable this, add the following to your `composer.json`:
   ```
-  "autoload-dev": {
+  "autoload-dev":
+  {
     "files": [
       "vendor/lullabot/drainpipe/scaffold/env/load.environment.php"
     ]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ Source and target need to have the same basedir (web or docroot) due to being
 unable to provide separate entryNames.
 See https://github.com/evanw/esbuild/issues/224
 
+## .env support
+Drainpipe will add `.env` file support for managing environment variables locally.
+This consists of:
+- Creation of a `.env` and `.env.defaults` file
+- DDEV integration to bring the environment variables into the DDEV web container
+- Drupal integration via [`vlucas/phpdotenv`](https://packagist.org/packages/vlucas/phpdotenv)
+  To enable this, add the following to your `composer.json`:
+  ```
+  "autoload-dev": {
+    "files": [
+      "vendor/lullabot/drainpipe/scaffold/env/load.environment.php"
+    ]
+  },
+  ```
+
 ## Validation
 
 Your `Taskfile.yml` can be validated with JSON Schema:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer-plugin-api": "^2.0",
         "drush/drush": "^10|^11",
         "symfony/yaml": "^3|^4",
-        "vlucas/phpdotenv": "^5.5"
+        "vlucas/phpdotenv": "^3|^4|^5"
     },
     "require-dev": {
         "composer/composer": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         "class": [
             "\\Lullabot\\Drainpipe\\ScaffoldInstallerPlugin",
             "\\Lullabot\\Drainpipe\\BinaryInstallerPlugin"
-        ]
-    },
-    "drupal-scaffold": {
-        "gitignore": true,
-        "file-mapping": {
-            "[project-root]/.ddev/docker-compose.env-file.yaml": "scaffold/ddev/docker-compose.env-file.yaml",
-            "[project-root]/.env": "scaffold/env/env"
+        ],
+        "drupal-scaffold": {
+            "gitignore": true,
+            "file-mapping": {
+                "[project-root]/.ddev/docker-compose.env-file.yaml": "scaffold/ddev/docker-compose.env-file.yaml",
+                "[project-root]/.env": "scaffold/env/env"
+            }
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,7 @@
         "psr-4": {"Lullabot\\Drainpipe\\": "src/"}
     },
     "autoload-dev": {
-        "psr-4": {"Lullabot\\Drainpipe\\Tests\\Functional\\": "tests/src/functional/"},
-        "files": [
-            "vendor/lullabot/drainpipe/scaffold/env/load.environment.php"
-        ]
+        "psr-4": {"Lullabot\\Drainpipe\\Tests\\Functional\\": "tests/src/functional/"}
     },
     "require": {
         "php": "^7.3||^8.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "composer-plugin-api": "^2.0",
         "drush/drush": "^10|^11",
         "symfony/yaml": "^3|^4",
-        "vlucas/phpdotenv": "^3|^4|^5"
+        "vlucas/phpdotenv": "^3|^4|^5",
+        "ext-json": "*"
     },
     "require-dev": {
         "composer/composer": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,10 @@
         "psr-4": {"Lullabot\\Drainpipe\\": "src/"}
     },
     "autoload-dev": {
-        "psr-4": {"Lullabot\\Drainpipe\\Tests\\Functional\\": "tests/src/functional/"}
+        "psr-4": {"Lullabot\\Drainpipe\\Tests\\Functional\\": "tests/src/functional/"},
+        "files": [
+            "vendor/lullabot/drainpipe/scaffold/env/load.environment.php"
+        ]
     },
     "require": {
         "php": "^7.3||^8.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": "^7.3||^8.0",
         "composer-plugin-api": "^2.0",
         "drush/drush": "^10|^11",
-        "symfony/yaml": "^3|^4"
+        "symfony/yaml": "^3|^4",
+        "vlucas/phpdotenv": "^5.5"
     },
     "require-dev": {
         "composer/composer": "^2.0",
@@ -24,6 +25,13 @@
             "\\Lullabot\\Drainpipe\\ScaffoldInstallerPlugin",
             "\\Lullabot\\Drainpipe\\BinaryInstallerPlugin"
         ]
+    },
+    "drupal-scaffold": {
+        "gitignore": true,
+        "file-mapping": {
+            "[project-root]/.ddev/docker-compose.env-file.yaml": "scaffold/ddev/docker-compose.env-file.yaml",
+            "[project-root]/.env": "scaffold/env/env"
+        }
     },
     "config": {
         "allow-plugins": {

--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-dotenv: ['.env.defaults,', '.env']
+dotenv: ['.env', '.env.defaults,']
 
 includes:
   deploy: ./vendor/lullabot/drainpipe/tasks/deploy.yml

--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-dotenv: ['.env', '.env.defaults,']
+dotenv: ['.env', '.env.defaults']
 
 includes:
   deploy: ./vendor/lullabot/drainpipe/tasks/deploy.yml

--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-dotenv: ['.env.defaults', '.env']
+dotenv: ['.env', '.env.defaults']
 
 includes:
   deploy: ./vendor/lullabot/drainpipe/tasks/deploy.yml

--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-dotenv: ['.env']
+dotenv: ['.env.defaults,', '.env']
 
 includes:
   deploy: ./vendor/lullabot/drainpipe/tasks/deploy.yml

--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-dotenv: ['.env', '.env.defaults']
+dotenv: ['.env.defaults', '.env']
 
 includes:
   deploy: ./vendor/lullabot/drainpipe/tasks/deploy.yml

--- a/scaffold/ddev/docker-compose.env-file.yaml
+++ b/scaffold/ddev/docker-compose.env-file.yaml
@@ -1,5 +1,6 @@
-# Enables docker-composer to load the .env file as a service during start. 
+# Enables docker-composer to load the .env file as a service during start.
 services:
   web:
     env_file:
+      - ../.env.defaults
       - ../.env

--- a/scaffold/ddev/env
+++ b/scaffold/ddev/env
@@ -1,1 +1,0 @@
-# Environment variables.

--- a/scaffold/ddev/env
+++ b/scaffold/ddev/env
@@ -1,0 +1,1 @@
+# Environment variables.

--- a/scaffold/env/env
+++ b/scaffold/env/env
@@ -1,1 +1,2 @@
 # Local environment variables.
+# You may need to restart any containers if making changes here

--- a/scaffold/env/env
+++ b/scaffold/env/env
@@ -1,0 +1,1 @@
+# Local environment variables.

--- a/scaffold/env/env.defaults
+++ b/scaffold/env/env.defaults
@@ -1,1 +1,2 @@
-# Default environment variables. These are only set for local development.
+# Default environment variables.
+# You may need to restart any containers if making changes here.

--- a/scaffold/env/env.defaults
+++ b/scaffold/env/env.defaults
@@ -1,0 +1,1 @@
+# Default environment variables. These are only set for local development.

--- a/scaffold/env/load.environment.php
+++ b/scaffold/env/load.environment.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Loads .env.defaults and .env files.
+ *
+ * See autoload.files in composer.json and
+ * https://getcomposer.org/doc/04-schema.md#files.
+ */
+
+use Dotenv\Dotenv;
+use Dotenv\Exception\InvalidPathException;
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__, '.env.defaults');
+$dotenv->load();
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__, '.env');
+$dotenv->load();

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -174,11 +174,13 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
         if (!is_file('./.env.defaults')) {
             $fs->copy($vendor . '/lullabot/drainpipe/scaffold/env/env.defaults', './.env.defaults');
         }
-        $autoloadDev = $this->config->get('autoload-dev');
-        if (empty($autoloadDev['files']) || !in_array($autoloadDev['files'], "$vendor/lullabot/drainpipe/scaffold/env/load.environment.php")) {
-            $this->io->warning("🪠 [Drainpipe] $vendor . '/lullabot/drainpipe/scaffold/env/load.environment.php' missing from autoload-dev files");
+        // There has to be a better way of doing this?
+        $vendorRelative = str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $vendor);
+        $composerJson = file_get_contents('composer.json');
+        $composerFullConfig = json_decode($composerJson, true);
+        if (empty($composerFullConfig['autoload-dev']['files']) || !in_array("$vendorRelative/lullabot/drainpipe/scaffold/env/load.environment.php", $composerFullConfig['autoload-dev']['files'])) {
+            $this->io->warning("🪠 [Drainpipe] $vendorRelative/lullabot/drainpipe/scaffold/env/load.environment.php' missing from autoload-dev files");
         }
-
     }
 
     /**

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -167,21 +167,15 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
     {
         if (file_exists('./.ddev/config.yaml')) {
             $vendor = $this->config->get('vendor-dir');
-            $ddevCommandPath = $vendor.'/lullabot/drainpipe/scaffold/ddev/task-command.sh';
+            $ddevCommandPath = $vendor . '/lullabot/drainpipe/scaffold/ddev/task-command.sh';
             $fs = new Filesystem();
             $fs->ensureDirectoryExists('./.ddev/commands/web');
             $fs->copy($ddevCommandPath, './.ddev/commands/web/task');
 
-            # Enable .env file support via docker-composer web environment.
-            $fs->copy($vendor . '/lullabot/drainpipe/scaffold/ddev/docker-compose.env-file.yaml', './.ddev/docker-compose.env-file.yaml');
-            if (!is_file('./.env')) {
-                $fs->copy($vendor . '/lullabot/drainpipe/scaffold/ddev/env', './.env');
-            }
-            if (strpos(file_get_contents("./.gitignore"), '/.ddev/docker-compose.env-file.yaml') !== false) {
-                file_put_contents('./.gitignore', "\n/.ddev/docker-compose.env-file.yaml\n", FILE_APPEND);
-            }
-            if (strpos(file_get_contents("./.gitignore"), '/.env') !== false) {
-                file_put_contents('./.gitignore', "\n/.env\n", FILE_APPEND);
+            # Copy this over as the other files in composer drupal-scaffold
+            # are added to the gitignore, and this should be checked in.
+            if (!is_file('./.env.defaults')) {
+                $fs->copy($vendor . '/lullabot/drainpipe/scaffold/env/env.defaults', './env.defaults');
             }
         }
     }

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -177,6 +177,10 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             if (!is_file('./.env.defaults')) {
                 $fs->copy($vendor . '/lullabot/drainpipe/scaffold/env/env.defaults', './env.defaults');
             }
+            $autoloadDev = $this->config->get('autoload-dev');
+            if (empty($autoloadDev['files']) || !in_array($autoloadDev['files'], 'vendor/lullabot/drainpipe/scaffold/env/load.environment.php')) {
+                $this->io->warning("🪠 [Drainpipe] 'vendor/lullabot/drainpipe/scaffold/env/load.environment.php' missing from autoload-dev files");
+            }
         }
     }
 

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -173,8 +173,15 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             $fs->copy($ddevCommandPath, './.ddev/commands/web/task');
 
             # Enable .env file support via docker-composer web environment.
-            if (is_file('./.env')) {
-                $fs->copy($vendor.'/lullabot/drainpipe/scaffold/ddev/docker-compose.env-file.yaml', './.ddev/docker-compose.env-file.yaml');
+            $fs->copy($vendor . '/lullabot/drainpipe/scaffold/ddev/docker-compose.env-file.yaml', './.ddev/docker-compose.env-file.yaml');
+            if (!is_file('./.env')) {
+                $fs->copy($vendor . '/lullabot/drainpipe/scaffold/ddev/env', './.env');
+            }
+            if (strpos(file_get_contents("./.gitignore"), '/.ddev/docker-compose.env-file.yaml') !== false) {
+                file_put_contents('./.gitignore', "\n/.ddev/docker-compose.env-file.yaml\n", FILE_APPEND);
+            }
+            if (strpos(file_get_contents("./.gitignore"), '/.env') !== false) {
+                file_put_contents('./.gitignore', "\n/.env\n", FILE_APPEND);
             }
         }
     }

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -175,7 +175,7 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             # Copy this over as the other files in composer drupal-scaffold
             # are added to the gitignore, and this should be checked in.
             if (!is_file('./.env.defaults')) {
-                $fs->copy($vendor . '/lullabot/drainpipe/scaffold/env/env.defaults', './env.defaults');
+                $fs->copy($vendor . '/lullabot/drainpipe/scaffold/env/env.defaults', './.env.defaults');
             }
             $autoloadDev = $this->config->get('autoload-dev');
             if (empty($autoloadDev['files']) || !in_array($autoloadDev['files'], 'vendor/lullabot/drainpipe/scaffold/env/load.environment.php')) {

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -81,6 +81,7 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
         $this->installGitignore();
         $this->installDdevCommand();
         $this->installCICommands();
+        $this->installEnvSupport();
     }
 
     /**
@@ -94,6 +95,7 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
         $this->installGitignore();
         $this->installDdevCommand();
         $this->installCICommands();
+        $this->installEnvSupport();
     }
 
     /**
@@ -161,6 +163,25 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
     }
 
     /**
+     * Install .env support.
+     */
+    private function installEnvSupport(): void
+    {
+        $fs = new Filesystem();
+        $vendor = $this->config->get('vendor-dir');
+        // Copy this over as the other files in composer drupal-scaffold
+        // are added to the gitignore, and this should be checked in.
+        if (!is_file('./.env.defaults')) {
+            $fs->copy($vendor . '/lullabot/drainpipe/scaffold/env/env.defaults', './.env.defaults');
+        }
+        $autoloadDev = $this->config->get('autoload-dev');
+        if (empty($autoloadDev['files']) || !in_array($autoloadDev['files'], "$vendor/lullabot/drainpipe/scaffold/env/load.environment.php")) {
+            $this->io->warning("🪠 [Drainpipe] $vendor . '/lullabot/drainpipe/scaffold/env/load.environment.php' missing from autoload-dev files");
+        }
+
+    }
+
+    /**
      * Install DDEV Commands.
      */
     private function installDdevCommand(): void
@@ -171,16 +192,6 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             $fs = new Filesystem();
             $fs->ensureDirectoryExists('./.ddev/commands/web');
             $fs->copy($ddevCommandPath, './.ddev/commands/web/task');
-
-            # Copy this over as the other files in composer drupal-scaffold
-            # are added to the gitignore, and this should be checked in.
-            if (!is_file('./.env.defaults')) {
-                $fs->copy($vendor . '/lullabot/drainpipe/scaffold/env/env.defaults', './.env.defaults');
-            }
-            $autoloadDev = $this->config->get('autoload-dev');
-            if (empty($autoloadDev['files']) || !in_array($autoloadDev['files'], 'vendor/lullabot/drainpipe/scaffold/env/load.environment.php')) {
-                $this->io->warning("🪠 [Drainpipe] 'vendor/lullabot/drainpipe/scaffold/env/load.environment.php' missing from autoload-dev files");
-            }
         }
     }
 

--- a/tests/fixtures/env/Taskfile-dotenv.yml
+++ b/tests/fixtures/env/Taskfile-dotenv.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-dotenv: ['.env.defaults', '.env']
+dotenv: ['.env', '.env.defaults']
 
 tasks:
   bar:

--- a/tests/fixtures/env/Taskfile-dotenv.yml
+++ b/tests/fixtures/env/Taskfile-dotenv.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-dotenv: ['.env', '.env.defaults,']
+dotenv: ['.env', '.env.defaults']
 
 tasks:
   bar:

--- a/tests/fixtures/env/Taskfile-dotenv.yml
+++ b/tests/fixtures/env/Taskfile-dotenv.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+dotenv: ['.env.defaults,', '.env']
+
+tasks:
+  bar:
+    cmds:
+      - if [ "$FOO" != "bar" ]; then exit 1; fi
+  baz:
+    cmds:
+      - if [ "$FOO" != "bar" ]; then exit 1; fi

--- a/tests/fixtures/env/Taskfile-dotenv.yml
+++ b/tests/fixtures/env/Taskfile-dotenv.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-dotenv: ['.env.defaults,', '.env']
+dotenv: ['.env', '.env.defaults,']
 
 tasks:
   bar:
@@ -8,4 +8,4 @@ tasks:
       - if [ "$FOO" != "bar" ]; then exit 1; fi
   baz:
     cmds:
-      - if [ "$FOO" != "bar" ]; then exit 1; fi
+      - if [ "$FOO" != "baz" ]; then exit 1; fi

--- a/tests/fixtures/env/Taskfile-dotenv.yml
+++ b/tests/fixtures/env/Taskfile-dotenv.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-dotenv: ['.env', '.env.defaults']
+dotenv: ['.env.defaults', '.env']
 
 tasks:
   bar:

--- a/tests/fixtures/env/Taskfile-no-dotenv.yml
+++ b/tests/fixtures/env/Taskfile-no-dotenv.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+tasks:
+  bar:
+    cmds:
+      - if [ "$FOO" != "bar" ]; then exit 1; fi
+  baz:
+    cmds:
+      - if [ "$FOO" != "baz" ]; then exit 1; fi


### PR DESCRIPTION
When pulling the added .env support into an existing project it blew everything up due to an `.env` file not being explicitly created by the CI or build process (which it shouldn't have to be!)

## Testing Instructions
- [ ] Add this to an existing project (`ddev composer require lullabot/drainpipe:"dev-justafish/fix-env-support as 1.2.16" -W`) and check things don't explode and you're able to setup environment variable support for both within DDEV containers and within Drupal
- [ ] Follow the instructions in the README to setup a new site and verify as above
