### PR TITLE
Move variables for Pantheon Review Apps to environment variables and always copy the Pantheon Review App scaffold in

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,11 @@ Requires `GITLAB_ACCESS_TOKEN` variable to be set, which is an access token with
   }
   ```
 - Run `composer install`
-- Add your Pantheon `site-name` to the last job in the new
-  workflow file at `.github/workflows/PantheonReviewApps.yml`
 - Add the following secrets to your repository:
   - `PANTHEON_TERMINUS_TOKEN` See https://pantheon.io/docs/terminus/install#machine-token
+  - `PANTHEON_SITE_NAME` The canonical site name
+  - `PANTHEON_REVIEW_USERNAME` (optional) A username for HTTP basic auth local
+  - `PANTHEON_REVIEW_PASSWORD` (optional) The password to lock the site with
   - `SSH_PRIVATE_KEY` A private key of a user which can push to Pantheon
   - `SSH_KNOWN_HOSTS` The result of running `ssh-keyscan -H codeserver.dev.$PANTHEON_SITE_ID.drush.in`
   - `TERMINUS_PLUGINS` Comma-separated list of Terminus plugins to be available (optional)

--- a/scaffold/github/workflows/PantheonReviewApps.yml
+++ b/scaffold/github/workflows/PantheonReviewApps.yml
@@ -68,5 +68,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terminus-token: ${{ secrets.PANTHEON_TERMINUS_TOKEN }}
-          site-name: [site-name]
           commit-message: ${{ github.event.head_commit.message }}
+          site-name: ${{ secrets.PANTHEON_SITE_NAME }}
+          lock-username: ${{ secrets.PANTHEON_REVIEW_USERNAME }}
+          lock-password: ${{ secrets.PANTHEON_REVIEW_PASSWORD }}

--- a/scaffold/github/workflows/PantheonReviewAppsDDEV.yml
+++ b/scaffold/github/workflows/PantheonReviewAppsDDEV.yml
@@ -40,10 +40,13 @@ jobs:
           ddev composer install
           ddev task build
           ddev task snapshot:directory directory=/tmp/release
+
       - name: Deploy Pantheon Review App
         uses: ./.github/actions/drainpipe/pantheon/review
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terminus-token: ${{ secrets.PANTHEON_TERMINUS_TOKEN }}
-          site-name: [site-name]
           commit-message: ${{ github.event.head_commit.message }}
+          site-name: ${{ secrets.PANTHEON_SITE_NAME }}
+          lock-username: ${{ secrets.PANTHEON_REVIEW_USERNAME }}
+          lock-password: ${{ secrets.PANTHEON_REVIEW_PASSWORD }}

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -243,13 +243,11 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
                     $fs->ensureDirectoryExists('./.github/actions/drainpipe/pantheon');
                     $fs->ensureDirectoryExists('./.github/workflows');
                     $fs->copy("$scaffoldPath/github/actions/pantheon", './.github/actions/drainpipe/pantheon');
-                    if (!file_exists('./.github/workflows/PantheonReviewApps.yml')) {
-                        if (file_exists('./.ddev/config.yaml')) {
-                            $fs->copy("$scaffoldPath/github/workflows/PantheonReviewAppsDDEV.yml", './.github/workflows/PantheonReviewApps.yml');
-                        }
-                        else {
-                            $fs->copy("$scaffoldPath/github/workflows/PantheonReviewApps.yml", './.github/workflows/PantheonReviewApps.yml');
-                        }
+                    if (file_exists('./.ddev/config.yaml')) {
+                        $fs->copy("$scaffoldPath/github/workflows/PantheonReviewAppsDDEV.yml", './.github/workflows/PantheonReviewApps.yml');
+                    }
+                    else {
+                        $fs->copy("$scaffoldPath/github/workflows/PantheonReviewApps.yml", './.github/workflows/PantheonReviewApps.yml');
                     }
                 }
             }


### PR DESCRIPTION
This allows Drainpipe to push updates to this action