### PR TITLE
Update path in dotenv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,12 @@ This consists of:
   "autoload-dev":
   {
     "files": [
-      "vendor/lullabot/drainpipe/scaffold/env/load.environment.php"
+      "vendor/lullabot/drainpipe/scaffold/env/dotenv.php"
     ]
   },
   ```
   **You will need to restart DDEV if you make any changes to `.env` or `.env.defaults`**
+
 ## Validation
 
 Your `Taskfile.yml` can be validated with JSON Schema:


### PR DESCRIPTION
I was taking a look at https://github.com/Lullabot/drainpipe/pull/151#event-7824247398 to see what changes I need in order to make dotenv work, and noticed what I think is a change in the filename that got pushed separately after that PR merged? Not 100% sure though.