### PR TITLE
Upgrade the 'cache' github action to v3 to clear warnings about nodejs version

### DIFF
--- a/.github/workflows/composer-plugin.yml
+++ b/.github/workflows/composer-plugin.yml
@@ -19,7 +19,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/test-production-build.yml
+++ b/.github/workflows/test-production-build.yml
@@ -27,7 +27,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/scaffold/github/workflows/PantheonReviewApps.yml
+++ b/scaffold/github/workflows/PantheonReviewApps.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/scaffold/github/workflows/PantheonReviewAppsDDEV.yml
+++ b/scaffold/github/workflows/PantheonReviewAppsDDEV.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/.ddev/.drainpipe-composer-cache
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
I didn't notice any regressions on a client project after upgrading the `actions/cache` action from v2 to v3. It cleared 4 warnings that were present in the UI.