### PR TITLE
Re-use test:config task in drupal:update

### DIFF
--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -65,7 +65,7 @@ tasks:
       - ./vendor/bin/drush {{.site}} --yes config:import
       - ./vendor/bin/drush {{.site}} --yes updatedb --no-cache-clear
       - ./vendor/bin/drush {{.site}} --yes cache:rebuild
-      - task: :test:config
+      - task: test:config
   maintenance:on:
     desc: Turn on Maintenance Mode
     cmds:

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -65,7 +65,7 @@ tasks:
       - ./vendor/bin/drush {{.site}} --yes config:import
       - ./vendor/bin/drush {{.site}} --yes updatedb --no-cache-clear
       - ./vendor/bin/drush {{.site}} --yes cache:rebuild
-      - task: test:config
+      - task: :test:config
   maintenance:on:
     desc: Turn on Maintenance Mode
     cmds:

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -65,12 +65,7 @@ tasks:
       - ./vendor/bin/drush {{.site}} --yes config:import
       - ./vendor/bin/drush {{.site}} --yes updatedb --no-cache-clear
       - ./vendor/bin/drush {{.site}} --yes cache:rebuild
-      - |
-        if [[ $(./vendor/bin/drush config:status --format=json --state=Different) != '[]' ]]; then
-          echo "Config export does not match database."
-          ./vendor/bin/drush config:status
-          exit 1;
-        fi
+      - task: :test:config
   maintenance:on:
     desc: Turn on Maintenance Mode
     cmds:


### PR DESCRIPTION
Just something I noticed. Not sure if there was a reason for not using `test:config` in the `drupal:update` task? Seemed to work like this for me locally.