### PR TITLE
Support quotes in the Pantheon deploy commit message

### DIFF
--- a/scaffold/github/actions/pantheon/push/action.yml
+++ b/scaffold/github/actions/pantheon/push/action.yml
@@ -26,5 +26,9 @@ runs:
         else
           drainpipe_exec "terminus connection:set ${{ inputs.site-name }}.${{ inputs.branch }} git --yes"
         fi
-        drainpipe_exec "./vendor/bin/task deploy:git directory=/tmp/release branch=${{ inputs.branch }} remote=ssh://codeserver.dev.$SITE_ID@codeserver.dev.$SITE_ID.drush.in:2222/~/repository.git message=\"${{ inputs.commit-message }}\""
+        COMMIT_MESSAGE=$(cat <<EOF
+          ${{ inputs.commit-message }}
+        EOF
+        )
+        drainpipe_exec "./vendor/bin/task deploy:git directory=/tmp/release branch=${{ inputs.branch }} remote=ssh://codeserver.dev.$SITE_ID@codeserver.dev.$SITE_ID.drush.in:2222/~/repository.git message=\"${COMMIT_MESSAGE}\""
       shell: bash

--- a/scaffold/github/actions/pantheon/review/action.yml
+++ b/scaffold/github/actions/pantheon/review/action.yml
@@ -93,8 +93,12 @@ runs:
       run: |
         source .github/actions/drainpipe/set-env/bash_aliases
         SITE_ID=$(drainpipe_exec "terminus site:lookup ${{ inputs.site-name }}")
+        COMMIT_MESSAGE=$(cat <<EOF
+          ${{ inputs.commit-message }}
+        EOF
+        )
         drainpipe_exec "terminus connection:set  ${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER git --yes"
-        drainpipe_exec "./vendor/bin/task deploy:git directory=/tmp/release branch=pr-$DRAINPIPE_PR_NUMBER remote=ssh://codeserver.dev.$SITE_ID@codeserver.dev.$SITE_ID.drush.in:2222/~/repository.git message=\"${{ inputs.commit-message }}\" site=${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER"
+        drainpipe_exec "./vendor/bin/task deploy:git directory=/tmp/release branch=pr-$DRAINPIPE_PR_NUMBER remote=ssh://codeserver.dev.$SITE_ID@codeserver.dev.$SITE_ID.drush.in:2222/~/repository.git message=\"${COMMIT_MESSAGE}\" site=${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER"
       shell: bash
 
     - name: Deploy to Pantheon


### PR DESCRIPTION
Commit messages with quotes in them were breaking due to the GitHub Actions template string replacement of the input variable. The quotes in the input variable were interacting with the quotes in the command string.

I haven't tested these actions directly as we're using our own deploy action (modified from Drainpipe's) but it's the same code :) 