### PR TITLE
Quiet git commit commands

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -31,7 +31,7 @@ tasks:
         cd {{.directory}}
         git checkout -B {{.branch}}
         git add -A
-        git commit -m {{shellQuote .message}} --allow-empty
+        git commit --quiet --message {{shellQuote .message}} --allow-empty
         git push origin {{.branch}}
         # Not using a bash-style comparison here due to https://github.com/go-task/task/issues/609
         {{if eq .push "true"}}git push origin {{.branch}}{{end}}

--- a/tasks/snapshot.yml
+++ b/tasks/snapshot.yml
@@ -61,7 +61,7 @@ tasks:
         {{ .PREPARE_DIRECTORY }}
         git config user.email 'no-reply@lullabot.com'
         git config user.name 'Lullabot Drainpipe'
-        git commit -m "Initial commit" --no-gpg-sign
+        git commit --quiet --message "Initial commit" --no-gpg-sign
         git config tar.tar.xz.command "xz -c"
         git config tar.tar.bz2.command "bzip2 -c"
         git archive -o {{.o}} HEAD


### PR DESCRIPTION
When running in CI, the commit command can generate tens of thousands of log lines for each file committed. This isn't very useful, and can start to lag browsers.

This PR adds `--quiet` and also switches `-m` to `--message` following https://architecture.lullabot.com/adr/20211006-avoid-command-aliases/.