### PR TITLE
Updating new lines scape character.

### DIFF
--- a/scaffold/github/workflows/ComposerLockDiff.yml
+++ b/scaffold/github/workflows/ComposerLockDiff.yml
@@ -43,7 +43,7 @@ jobs:
             -H "Authorization: Bearer  ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/${{ github.repository }}/pulls/$DRAINPIPE_PR_NUMBER | jq '. | {body}' > pull_request.json
           sed -i 's/<!--Composer Lock Diff-->.*<!--\/Composer Lock Diff-->//g' pull_request.json
-          DESCRIPTION=$(cat pull_request.json | jq -r '.body' | sed -z 's/\r\n/\\n/g')
+          DESCRIPTION=$(cat pull_request.json | jq -r '.body' | sed -z 's/\r/\\r/g')
           if [ "$(cat composer_lock_diff.md)" != "" ]; then
             DIFF=$(cat composer_lock_diff.md | sed -z "s/\n/\\\n/g")
             DESCRIPTION="$DESCRIPTION\\n<!--Composer Lock Diff-->\\n## Composer Lock Diff\\n$DIFF\\n<!--/Composer Lock Diff-->"


### PR DESCRIPTION
**Testing**

 - Create a new branch, and push some updates in composer, this could be a module or library.
 - Create a PR, add any text, image, or formatted text in the PR description
 - The ComposerLockDiff build should finish successfully and the description should be updated automatically.
 - The description should keep the same Description content format and the ComposerLockDiff content added at the end of it.
 - Create another composer.lock change and verify the composer lock diff table in the description is updated, and the description is not corrupted. (In previous solutions, when the bot ran twice back to back without a human editing in between the bot runs, then the description would get new lines removed, or added.)
 - Try with renovatebot PR descriptions also.

**About this change**

- *The first solution* we tried is: `sed -z 's/["\n\r]/\\n/g')` which replaces new lines `\r` OR `\n` with `\n` but it was generating duplicated new lines.
- *The second solution* was: `sed -z 's/\r\n/\\n/g')`, in this case, we are replacing specifically `\r\n` with `\n`, the problem here was when trying to rebuild the `ComposerLockDiff` build the new lines were disappearing, getting one line description.
- *The current solution*: `sed -z 's/\r/\\r/g')`, it replaces the new line `\r` (special character) that doesn't appear as a character in the plain text retrieved from Github (PR description) with the `\r` which in this case is a single text (not the special character), having this solution, when we send the updated Description the JSON data doesn't break and the description is updated correctly with the original description. In a summary, the `\r` is a special character and we are replacing it with `\r` as a single text.