### PR TITLE
Add usePolling to sass watch

### DIFF
--- a/metapackages/sass/gulpfile.js
+++ b/metapackages/sass/gulpfile.js
@@ -84,7 +84,9 @@ task('development', function() {
 
 task('sass:watch', function() {
   console.log('🪠 Watching for changes');
-  watch(includes, series('development'));
+  watch(includes, {
+      usePolling: true,
+  }, series('development'));
 });
 
 series(['sass']);

--- a/metapackages/sass/package.json
+++ b/metapackages/sass/package.json
@@ -4,16 +4,16 @@
   "bin": "./gulp.js",
   "dependencies": {
     "autoprefixer": "^10.4.4",
-    "cssnano": "^5.1.7",
+    "cssnano": "^6.0.0",
     "gulp": "^4.0.2",
     "gulp-postcss": "^9.0.1",
     "gulp-sass": "^5.1.0",
     "gulp-sass-glob": "^1.1.0",
     "gulp-sourcemaps": "^3.0.0",
     "modern-normalize": "^1.1.0",
-    "postcss": "^8.4.12",
-    "sass": "^1.50.0",
-    "yargs": "^17.4.1"
+    "postcss": "^8.4.21",
+    "sass": "^1.62.0",
+    "yargs": "^17.7.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The Chokidar version is old and broken on Macs https://github.com/gulpjs/glob-watcher/issues/49

To test:
- 'yarn unplug @lullabot/drainpipe-sass`
- Replace `.yarn/unplugged/@lullabot-drainpipe-sass-npm<some other stuff>/node_modules/@lullabot/drainpipe-sass` with the new `gulpfile.js` and `package.json`
- Run `ddev yarn`
- Try and save a file multiple times and see if sass watch picks up on it