### PR TITLE
Force to Use strict types in PHP code

### DIFF
--- a/drainpipe-dev/scaffold/phpcs.xml
+++ b/drainpipe-dev/scaffold/phpcs.xml
@@ -20,6 +20,9 @@
         <exclude name="Drupal.Semantics.FunctionT.NotLiteralString"/>
     </rule>
 
+    <!-- See ADR: Use strict types in PHP code -->
+    <rule ref="Generic.PHP.RequireStrictTypes"/>
+
     <file>web/modules/custom</file>
     <file>web/themes/custom</file>
     <file>web/sites</file>


### PR DESCRIPTION
https://architecture.lullabot.com/adr/20211201-use-strict-types-in-php-code/