### PR TITLE
Specify prettier cache location to avoid secondary effects

### DIFF
--- a/scaffold/gitignore/common.gitignore
+++ b/scaffold/gitignore/common.gitignore
@@ -54,3 +54,4 @@ node_modules
 # Tests #
 #########
 test_result
+.prettiercache

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -61,7 +61,7 @@ tasks:
         done
       - |
         if [ -f ".prettierrc.json" ] && [ -f "yarn.lock" ]; then
-          yarn prettier --check .
+          yarn prettier --check --cache-location=.prettiercache .
         elif [ -f ".prettierrc.json" ] && [ -f "package-lock.json" ]; then
           npm run prettier --check .
         fi


### PR DESCRIPTION
prettier is currently creating an empty folder in `node_modules`.
This folder conflicts with other tasks like `assets`, that expects that ´node_modules` is not present to run yarn commands.
See https://github.com/prettier/prettier/issues/13032