### PR TITLE
Fixes Nightwatch integration for Nightwatch v3.1.0

### DIFF
--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Setup Project
         run: |
           ddev config --auto
+          ddev config --nodejs-version "18"
           ddev start
           ddev composer config extra.drupal-scaffold.gitignore true
           ddev composer config --json extra.drupal-scaffold.allowed-packages '["lullabot/drainpipe-dev", "lullabot/drainpipe"]'
@@ -247,7 +248,8 @@ jobs:
           echo '  "nightwatch@*":' >> .yarnrc.yml
           echo '    dependencies:' >> .yarnrc.yml
           echo '      ws: "*"' >> .yarnrc.yml
-          ddev yarn add nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands ws --dev
+          echo '      lodash: "*"' >> .yarnrc.yml
+          ddev yarn add nightwatch nightwatch-axe-verbose @lullabot/nightwatch-drupal-commands --dev
           yarn
 
       - name: Install Drupal

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Nightwatch
         run: |
           ddev npm init -y
-          ddev npm install nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands --save-dev
+          ddev npm install nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands lodash --save-dev
 
       - name: Install Drupal
         run: |
@@ -145,7 +145,7 @@ jobs:
         run: |
           ddev yarn set version classic
           ddev yarn init -y
-          ddev yarn add nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands --dev
+          ddev yarn add nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands lodash --dev
 
       - name: Install Drupal
         run: |
@@ -195,7 +195,7 @@ jobs:
           ddev yarn set version berry
           ddev yarn init -y
           yarn config set nodeLinker node-modules
-          ddev yarn add nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands --dev
+          ddev yarn add nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands lodash --dev
 
       - name: Install Drupal
         run: |

--- a/drainpipe-dev/config/nightwatch.conf.js
+++ b/drainpipe-dev/config/nightwatch.conf.js
@@ -1,15 +1,6 @@
-let a11yPath, drupalCommandsPath;
-let yarn2 = false;
-try {
-  const { resolveToUnqualified } = require('pnpapi');
-  a11yPath = resolveToUnqualified('nightwatch-accessibility', __filename).replace(/\/$/, '');
-  drupalCommandsPath = resolveToUnqualified('@lullabot/nightwatch-drupal-commands', __filename).replace(/\/$/, '');
-  yarn2 = true;
-} catch(e) {
-  a11yPath = './node_modules/nightwatch-accessibility/nightwatch';
-  drupalCommandsPath = './node_modules/@lullabot/nightwatch-drupal-commands';
-}
+const path = require('path');
 
+const drupalCommandsPath = path.dirname(require.resolve('@lullabot/nightwatch-drupal-commands/README.md'));
 const firefoxLaunchUrl = process.env.NIGHTWATCH_DRUPAL_URL_FIREFOX && process.env.NIGHTWATCH_DRUPAL_URL_FIREFOX.length ? process.env.NIGHTWATCH_DRUPAL_URL_FIREFOX.replace(/\/$/, '') : process.env.NIGHTWATCH_DRUPAL_URL;
 const chromeLaunchUrl = process.env.NIGHTWATCH_DRUPAL_URL_CHROME && process.env.NIGHTWATCH_DRUPAL_URL_CHROME.length ? process.env.NIGHTWATCH_DRUPAL_URL_CHROME.replace(/\/$/, '') : process.env.NIGHTWATCH_DRUPAL_URL;
 
@@ -24,10 +15,10 @@ module.exports = {
   page_objects_path: [`${drupalCommandsPath}/page_objects`],
 
   // See https://nightwatchjs.org/guide/extending-nightwatch/#writing-custom-commands
-  custom_commands_path:  [`${a11yPath}/commands`, `${drupalCommandsPath}/commands`],
+  custom_commands_path:  [`${drupalCommandsPath}/commands`],
 
   // See https://nightwatchjs.org/guide/extending-nightwatch/#writing-custom-assertions
-  custom_assertions_path: [`${a11yPath}/assertions`],
+  custom_assertions_path: [],
 
   // See https://nightwatchjs.org/guide/#external-globals
   globals_path : '',

--- a/drainpipe-dev/scaffold/nightwatch/example.nightwatch.js
+++ b/drainpipe-dev/scaffold/nightwatch/example.nightwatch.js
@@ -1,7 +1,8 @@
 module.exports = {
   'Demo test' : function(browser) {
     browser
-      .initAccessibility()
+      .axeInject()
+      .axeRun('body')
       .drupalUrl('/user')
       .assert.titleContains('Log in')
       .drush('user:login', (url) => {

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -217,11 +217,11 @@ tasks:
               sudo npm update -g
             fi
             npm init -y
-            npm install $PACKAGES --save-dev
+            npm install $PACKAGES lodash --save-dev
           elif [ "$PACKAGE_MANAGER" == "yarn1" ]; then
             yarn set version classic
             yarn init -y
-            yarn add $PACKAGES --dev
+            yarn add $PACKAGES lodash --dev
           elif [ "$PACKAGE_MANAGER" == "yarn" ]; then
             yarn set version berry
             yarn init
@@ -236,9 +236,9 @@ tasks:
           fi
         else
           if [ -f "package-lock.json" ]; then
-            npm install $PACKAGES --save-dev
+            npm install $PACKAGES lodash --save-dev
           elif [ -f "yarn.lock" ]; then
-            yarn add $PACKAGES --dev
+            yarn add $PACKAGES lodash --dev
           else
             echo "package.json found but unable to figure out which package manager is in use"
             echo "Please manually install $PACKAGES"

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -208,7 +208,7 @@ tasks:
     interactive: true
     cmds:
       - |
-        PACKAGES="nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands"
+        PACKAGES="nightwatch nightwatch-axe-verbose @lullabot/nightwatch-drupal-commands"
         if [ ! -f "package.json" ]; then
           echo -n "No package.json exists, would you like to use yarn1, npm, or yarn? "
           read -r PACKAGE_MANAGER
@@ -225,6 +225,11 @@ tasks:
           elif [ "$PACKAGE_MANAGER" == "yarn" ]; then
             yarn set version berry
             yarn init
+            echo "packageExtensions:" >> .yarnrc.yml
+            echo '  "nightwatch@*":' >> .yarnrc.yml
+            echo '    dependencies:' >> .yarnrc.yml
+            echo '      ws: "*"' >> .yarnrc.yml
+            echo '      lodash: "*"' >> .yarnrc.yml
             yarn add $PACKAGES --dev
           else
             echo "Sorry I'm not aware of that package manager. Please first init package.json with it yourself manually."

--- a/tests/local-test.sh
+++ b/tests/local-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eux
+# Helper script to setup a local test of Drainpipe
+# Copy this to the same directory level that your drainpipe directory is in
+composer create-project drupal/recommended-project drainpipe-test --ignore-platform-req=ext-gd
+cd drainpipe-test
+cp -R ../drainpipe .
+
+ddev config --auto
+ddev config --nodejs-version "18"
+ddev start
+ddev composer config extra.drupal-scaffold.gitignore true
+ddev composer config --json extra.drupal-scaffold.allowed-packages '["lullabot/drainpipe-dev", "lullabot/drainpipe"]'
+ddev composer config --no-plugins allow-plugins.composer/installers true
+ddev composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
+ddev composer config --no-plugins allow-plugins.lullabot/drainpipe true
+ddev composer config --no-plugins allow-plugins.lullabot/drainpipe-dev true
+ddev composer config repositories.drainpipe --json '{"type": "path", "url": "drainpipe", "options": {"symlink": false}}'
+ddev composer config repositories.drainpipe-dev --json '{"type": "path", "url": "drainpipe/drainpipe-dev", "options": {"symlink": false}}'
+ddev composer config minimum-stability dev
+ddev composer require "lullabot/drainpipe @dev" --with-all-dependencies
+ddev composer require "lullabot/drainpipe-dev @dev" --dev --with-all-dependencies
+rm -rf drainpipe
+
+echo "hooks:" >> .ddev/config.yaml
+echo "  post-start:" >> .ddev/config.yaml
+echo "    - exec: mysql -uroot -proot -hdb -e \"CREATE DATABASE IF NOT EXISTS firefox; GRANT ALL ON firefox.* TO 'db'@'%';\"" >> .ddev/config.yaml
+echo "    - exec: mysql -uroot -proot -hdb -e \"CREATE DATABASE IF NOT EXISTS chrome; GRANT ALL ON chrome.* TO 'db'@'%';\"" >> .ddev/config.yaml
+ddev config --web-environment="NIGHTWATCH_DRUPAL_URL_FIREFOX=https://drupal_firefox,NIGHTWATCH_DRUPAL_URL_CHROME=https://drupal_chrome"
+ddev config --additional-hostnames="*.drainpipe"
+ddev restart
+
+ddev yarn set version berry
+ddev yarn init -y
+echo "packageExtensions:" >> .yarnrc.yml
+echo '  "nightwatch@*":' >> .yarnrc.yml
+echo '    dependencies:' >> .yarnrc.yml
+echo '      ws: "*"' >> .yarnrc.yml
+echo '      lodash: "*"' >> .yarnrc.yml
+ddev yarn add nightwatch nightwatch-axe-verbose @lullabot/nightwatch-drupal-commands --dev
+yarn
+
+ddev drush --yes site:install
+ddev drush --uri=https://drupal_firefox --yes site:install
+ddev drush --uri=https://drupal_chrome --yes site:install
+ddev drush config:export --yes


### PR DESCRIPTION
Upgrading your project will require you to:
- Remove `nightwatch-accessibility`
- Add `nightwatch-axe-verbose`
- Swap `.initAccessibility()` for ` .axeInject()` e.g.
  ```
  browser
      .axeInject()
      .axeRun('body')
  ```
- If using Yarn Berry, `.yarnrc.yml` will need to contain the following:
  ```
  packageExtensions:
    "nightwatch@*":
      dependencies:
        ws: "*"
        lodash: "*"
  ```
- Other package managers should add `lodash` manually to `devDependencies`