### PR TITLE
Fix incosistency in deploy.yml file

### DIFF
--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   Test-GitHub-Actions:
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
     steps:
       - name: Create a Drupal project
         run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ See [.github/workflows/validate-taskfile.yml](`.github/workflows/validate-taskfi
 for an example of this in use.
 
 ```
-💡 If your docroot is not the standard `web/` path, you must create a symlink to it
-ln -s web/ docroot
+💡 If your docroot is not the standard `web/` path, you must create a symlink to
+it ln -s web/ docroot
 ```
 
 ---

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -7,7 +7,7 @@ tasks:
       Given a directory, pushes it to a git remote whilst maintaining a linear
       history with the remote.
 
-      usage: task deploy:git d="/tmp/release" b=main r="git@github.com:Lullabot/drainpipe.git" m="Initial commit" ge="bot@example.com" gn="Drainpipe Bot"
+      usage: task deploy:git directory="/tmp/release" branch=main remote="git@github.com:Lullabot/drainpipe.git" message="Initial commit" push=true
 
       directory=<directory>   A directory containing the files to be pushed
       branch=<branch>         Name of the branch to push to e.g. "main"
@@ -32,6 +32,6 @@ tasks:
         git checkout -B {{.branch}}
         git add -A
         git commit --quiet --message {{shellQuote .message}} --allow-empty
-        git push origin {{.branch}}
-        # Not using a bash-style comparison here due to https://github.com/go-task/task/issues/609
-        {{if eq .push "true"}}git push origin {{.branch}}{{end}}
+        if [ "" == {{shellQuote .push}} ] || [ {{shellQuote .push}} == "true" ]; then
+          git push origin {{.branch}}
+        fi


### PR DESCRIPTION
Deploy task summary says that it accepts a "push parameter to push or not the code to the remote repository.

However, it pushes the code even if this flag is not set to true.

This PR removes the extra push done before the flag checkin.
Also changes the if clause because https://github.com/go-task/task/issues/609 is already fixed.
Finally the command usage example is modified to reflect the actual task behavior