### PR TITLE
Avoid creation of unwanted node_modules folder as part of test:autofix

### DIFF
--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -159,7 +159,7 @@ tasks:
       - ./vendor/bin/phpcbf
       - |
         if [ -f ".prettierrc.json" ] && [ -f "yarn.lock" ]; then
-          yarn prettier --write .
+          yarn prettier --write --cache-location=.prettiercache .
         elif [ -f ".prettierrc.json" ] && [ -f "package-lock.json" ]; then
           npm run prettier --write .
         fi


### PR DESCRIPTION
This is a followup from #223 

When running `task test:autofix`, the unwanted `node_modules` folder is created and new execution of other tasks that checks the existence of this folder, like `task sass:compile` fail.

This can be mitigated removing manually the `node_modules` before executing the command, but this solution, avoids the folder generation