### PR TITLE
Update tugboat environment indicator colours to match ADR

### DIFF
--- a/scaffold/pantheon/settings.pantheon.php
+++ b/scaffold/pantheon/settings.pantheon.php
@@ -108,6 +108,6 @@ elseif (getenv('PANTHEON_ENVIRONMENT') === 'live') {
 }
 else {
   $config['environment_indicator.indicator']['name'] = 'Multidev (' . getenv('PANTHEON_ENVIRONMENT') . ')';
-  $config['environment_indicator.indicator']['bg_color'] = '#efd01b';
-  $config['environment_indicator.indicator']['fg_color'] = '#000000';
+  $config['environment_indicator.indicator']['bg_color'] = '#990055';
+  $config['environment_indicator.indicator']['fg_color'] = '#fff';
 }

--- a/scaffold/tugboat/settings.tugboat.php.twig
+++ b/scaffold/tugboat/settings.tugboat.php.twig
@@ -28,7 +28,8 @@ if (file_exists(__DIR__ . '/settings.tugboat.php') && getenv('TUGBOAT_PREVIEW_ID
     '\.tugboatqa\.com$',
   ];
 
+  # Following https://architecture.lullabot.com/adr/20210609-environment-indicator/
   $config['environment_indicator.indicator']['name'] = '☑️ Tugboat';
-  $config['environment_indicator.indicator']['bg_color'] = '#07688c';
+  $config['environment_indicator.indicator']['bg_color'] = '#990055';
   $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
 }


### PR DESCRIPTION
They should match "branch preview" at https://architecture.lullabot.com/adr/20210609-environment-indicator/.