### PR TITLE
Fix TUGBOAT_PREVIEW_ID not existing in build step

### DIFF
--- a/scaffold/tugboat/settings.tugboat.php.twig
+++ b/scaffold/tugboat/settings.tugboat.php.twig
@@ -10,7 +10,7 @@
 
 declare(strict_types=1);
 
-if (file_exists(__DIR__ . '/settings.tugboat.php') && getenv('TUGBOAT_PREVIEW_ID')) {
+if (getenv('TUGBOAT_REPO')) {
   $databases['default']['default'] = [
     'database' => 'tugboat',
     'username' => 'tugboat',


### PR DESCRIPTION
The preview only exists after it's built. That means if you're trying to bootstrap Drupal during a build (database updates, config imports, etc) the database settings won't work.

As well, I removed the file check because it's only checking for itself.