### PR TITLE
Convert variables to support defaults with override #267

### DIFF
--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -63,12 +63,11 @@ jobs:
 
       - name: Confirm custom directories are scanned
         run: |
+          set -x
           mkdir -p custom-yaml-directory
           echo 'key: value' >> custom-yaml-directory/test.yml
-          # Show the version in case future updates break this.
-          composer show j13k/yaml-lint
           ddev task test:static YAML_DIRS="custom-yaml-directory/*.yml" | tee static.log
-          grep -q 'parsing custom-yaml-directory/test.yml' static.log
+          [[ $(grep '[OK] All 1 YAML files contain valid syntax.' static.log | wc -l) -eq 1 ]]
 
       - name: Upload test artifacts
         if: ${{ always() }}

--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -67,7 +67,7 @@ jobs:
           mkdir -p custom-yaml-directory
           echo 'key: value' >> custom-yaml-directory/test.yml
           ddev task test:static YAML_DIRS="custom-yaml-directory/*.yml" | tee static.log
-          [[ $(grep '[OK] All 1 YAML files contain valid syntax.' static.log | wc -l) -eq 1 ]]
+          [[ $(grep '\[OK] All 1 YAML files contain valid syntax.' static.log | wc -l) -eq 1 ]]
 
       - name: Upload test artifacts
         if: ${{ always() }}

--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -65,7 +65,9 @@ jobs:
         run: |
           mkdir -p custom-yaml-directory
           echo 'key: value' >> custom-yaml-directory/test.yml
-          ddev task test:static YAML_DIRS="custom-yaml-directory" | tee static.log
+          # Show the version in case future updates break this.
+          composer show j13k/yaml-lint
+          ddev task test:static YAML_DIRS="custom-yaml-directory/*.yml" | tee static.log
           grep -q 'parsing custom-yaml-directory/test.yml' static.log
 
       - name: Upload test artifacts

--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Run Static Tests
         run: ddev task test:static
 
+      - name: Confirm custom directories are scanned
+        run: |
+          mkdir -p custom-yaml-directory
+          echo 'key: value' >> custom-yaml-directory/test.yml
+          ddev task test:static YAML_DIRS="custom-yaml-directory" | tee static.log
+          grep -q 'parsing custom-yaml-directory/test.yml' static.log
+
       - name: Upload test artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/drainpipe-dev/composer.json
+++ b/drainpipe-dev/composer.json
@@ -14,7 +14,6 @@
         "ext-json": "*",
         "composer-plugin-api": "^2.0",
         "phpunit/phpunit": "^8|^9",
-        "j13k/yaml-lint": "^1.1",
         "sserbin/twig-linter": "^3.0",
         "mikey179/vfsstream": "^1.6",
         "mockery/mockery": "^1.4",

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -1,15 +1,13 @@
 version: '3'
 
-# @todo allow these to be overridden or document them as required folder
-# structures. See also config/phpstan.neon
 vars:
-  YAML_DIRS: 'web/**/*.yml'
-  TWIG_DIRS: 'web/modules web/profiles web/themes'
+  YAML_DIRS: '{{ default "web/**/*.yml" .YAML_DIRS }}'
+  TWIG_DIRS: '{{ default "web/modules web/profiles web/themes" .TWIG_DIRS }}'
   # These directories are configured in phpcs.xml. However, phpcs will fail if
   # those directories do not exist, so we create them with the assumption that
   # every Drupal site will eventually have these directories.
-  TEST_DIRS: 'web/modules/custom web/themes/custom web/sites'
-  NIGHTWATCH_TEST_DIRS: 'test'
+  TEST_DIRS: '{{ default "web/modules/custom web/themes/custom web/sites" .TEST_DIRS }}'
+  NIGHTWATCH_TEST_DIRS: '{{ default "test" .NIGHTWATCH_TEST_DIRS }}'
   FUNC_ENSURE_DIRS: |
     DIRS_ARR=({{.TEST_DIRS}})
     for DIR in "${DIRS_ARR[@]}"; do


### PR DESCRIPTION
This lets callers override test directories, as asked for in #267.

Since this is really task functionality, I only added a test for the YAML directories since that seemed to be the simplest to test.

In doing that I discovered something surprising. The symfony yaml library now also ships a `yaml-lint` command, which takes precedence over the one we were using. Since `j13k/yaml-lint` used symfony under the hood, I just removed the dependency.