### PR TITLE
Issue #454: Action to push code to Acquia

### DIFF
--- a/scaffold/github/actions/acquia/push/action.yml
+++ b/scaffold/github/actions/acquia/push/action.yml
@@ -1,0 +1,20 @@
+name: Push code to Acquia
+description: Push code to the Acquia repository
+inputs:
+  repo-url:
+    description: "Repository URL"
+    required: true
+  branch:
+    description: "Which branch to push to"
+    required: true
+  commit-message:
+    description: "Commit message"
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Push code to Acquia
+      run: |
+        source .github/actions/drainpipe/set-env/bash_aliases
+        drainpipe_exec "task deploy:git directory=/tmp/release branch=${{ inputs.branch }} remote=${{ inputs.repo-url }} message=\"${{ inputs.commit-message }}\""
+      shell: bash


### PR DESCRIPTION
Fixes #454.

To code this I'm using `"lullabot/drainpipe": "dev-172--global-binaries as 3.3.0"`.

For the action to call, I'm running this:
```
      - name: Push code to Acquia
        uses: ./.github/actions/acquia/push
        with:
          repo-url: "git@my-repo.git"
          branch: "main"
          commit-message: "main compiled from Github"
```

But these variables can be replaced with github variables.