### PR TITLE
Fix variables in setup-ssh GitHub action

### DIFF
--- a/scaffold/github/actions/common/setup-ssh/action.yml
+++ b/scaffold/github/actions/common/setup-ssh/action.yml
@@ -18,8 +18,8 @@ runs:
         chmod 700 ~/.ssh
         touch ~/.ssh/config
         chmod 600 ~/.ssh/config
-        if [ "{{ inputs.ssh-known-hosts}}" != "" ]; then
-          echo "$ {{ inputs.ssh-known-hosts }}" >> ~/.ssh/known_hosts
+        if [ "${{ inputs.ssh-known-hosts}}" != "" ]; then
+          echo "${{ inputs.ssh-known-hosts }}" >> ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
         fi
       shell: bash


### PR DESCRIPTION
Looks like the variable syntax in the github ssh action isn't right.