### PR TITLE
Fix setup-ssh action apt install commands.

### DIFF
--- a/scaffold/github/actions/common/setup-ssh/action.yml
+++ b/scaffold/github/actions/common/setup-ssh/action.yml
@@ -11,7 +11,8 @@ runs:
   using: "composite"
   steps:
     - run: |
-        sudo apt install openssh-client
+        sudo apt-get update
+        sudo apt-get install -y openssh-client
         eval $(ssh-agent -s)
         echo "${{ inputs.ssh-private-key }}" | tr -d '\r' | ssh-add -
         mkdir -p ~/.ssh


### PR DESCRIPTION
I'm using this action with a GitHub workflow with `container: drupalci/php-8.1-apache`.

The setup-ssh action doesn't work.

This fixes it.

- Use `apt-get` command.
- Run `apt-get update` to ensure package lists are up to date.
- Use `-y` on install so it works non-interactively.