### PR TITLE
Issue #385: Update actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/TestComposerLockDiff.yml
+++ b/.github/workflows/TestComposerLockDiff.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: processed-descriptions
           path: |

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -62,7 +62,7 @@ jobs:
         run: zip -r /tmp/drainpipe.zip ./
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-functional-build
           path: /tmp/drainpipe.zip
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-functional-build
 
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-functional-build
 
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-functional-build
 
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result
@@ -219,7 +219,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-functional-build
 
@@ -263,7 +263,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result
@@ -272,7 +272,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-functional-build
 
@@ -317,7 +317,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result
@@ -326,7 +326,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-functional-build
 
@@ -373,7 +373,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -112,7 +112,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-npm
           path: test_result
 
   Test-Yarn-Classic:
@@ -161,7 +161,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-yarn-classic
           path: test_result
 
   Test-Yarn-3-Node-Linker:
@@ -212,7 +212,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-yarn3-nl
           path: test_result
 
   Test-Yarn-4-Node-Linker:
@@ -265,7 +265,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-yarn4-nl
           path: test_result
 
   Test-Yarn-3:
@@ -319,7 +319,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-yarn3
           path: test_result
 
   Test-Yarn-4:
@@ -375,5 +375,5 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-yarn4
           path: test_result

--- a/.github/workflows/TestMetapackages.yml
+++ b/.github/workflows/TestMetapackages.yml
@@ -59,7 +59,7 @@ jobs:
         run: zip -r /tmp/drainpipe.zip ./
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-metapackage-build
           path: /tmp/drainpipe.zip
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-metapackage-build
 
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-metapackage-build
 
@@ -137,7 +137,7 @@ jobs:
      runs-on: ubuntu-22.04
      needs: Build
      steps:
-       - uses: actions/download-artifact@v3
+       - uses: actions/download-artifact@v4
          with:
            name: test-metapackage-build
 
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-metapackage-build
 
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-metapackage-build
 
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-metapackage-build
 
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-metapackage-build
 
@@ -320,7 +320,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-metapackage-build
 

--- a/.github/workflows/TestPHPUnit.yml
+++ b/.github/workflows/TestPHPUnit.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-phpunit-functional
           path: test_result
 
       - name: Confirm All PHPUnit Functional Tests were run
@@ -140,7 +140,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-phpunit-dtt
           path: test_result
 
       - name: Confirm All PHPUnit Functional Tests were run
@@ -205,7 +205,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-phpunit-static
           path: test_result
 
       - name: Confirm All PHPUnit Functional Tests were run

--- a/.github/workflows/TestPHPUnit.yml
+++ b/.github/workflows/TestPHPUnit.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result
@@ -203,7 +203,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result

--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_result
           path: test_result

--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -73,5 +73,5 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
+          name: test_result-static
           path: test_result

--- a/.github/workflows/TestTugboat.yml
+++ b/.github/workflows/TestTugboat.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: .tugboat
           path: .tugboat

--- a/scaffold/github/workflows/ComposerLockDiff.yml
+++ b/scaffold/github/workflows/ComposerLockDiff.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.ddev/.drainpipe-composer-cache
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/scaffold/github/workflows/PantheonReviewApps.yml
+++ b/scaffold/github/workflows/PantheonReviewApps.yml
@@ -19,14 +19,14 @@ jobs:
   Drainpipe-Deploy-Pantheon-Multidev:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/scaffold/github/workflows/PantheonReviewAppsDDEV.yml
+++ b/scaffold/github/workflows/PantheonReviewAppsDDEV.yml
@@ -12,9 +12,9 @@ jobs:
   Drainpipe-Deploy-Pantheon-Multidev:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.ddev/.drainpipe-composer-cache
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
v3 actions are using node 16, which is EOL, giving some warnings.

This updates:

- actions/upload-artifact
- actions/download-artifact
- actions/cache
- actions/checkout

The artifacts need to be renamed on upload, as they aren't merged by default anymore. See https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
I've let different artifacts, if we still want to merge the test results is doable, but not sure if we want that.