### PR TITLE
Fix drainpipe-dev workflow when run as a tag

### DIFF
--- a/.github/workflows/DrainpipeDev.yml
+++ b/.github/workflows/DrainpipeDev.yml
@@ -36,7 +36,7 @@ jobs:
           git branch -m ${{ github.ref_name }}
           git remote add origin git@github.com:Lullabot/drainpipe-dev.git
           git fetch origin
-          git reset --mixed ${{ github.ref_name }} || git reset --mixed origin/main
+          git reset --mixed origin/${{ github.ref_name }} || git reset --mixed origin/main
           git config user.name "Lullabot-Drainpipe[bot]"
           git config user.email "157769597+Lullabot-Drainpipe[bot]@users.noreply.github.com"
 

--- a/.github/workflows/DrainpipeDev.yml
+++ b/.github/workflows/DrainpipeDev.yml
@@ -36,7 +36,7 @@ jobs:
           git branch -m ${{ github.ref_name }}
           git remote add origin git@github.com:Lullabot/drainpipe-dev.git
           git fetch origin
-          git reset --mixed origin/${{ github.ref_name }}
+          git reset --mixed origin/main
           git config user.name "Lullabot-Drainpipe[bot]"
           git config user.email "157769597+Lullabot-Drainpipe[bot]@users.noreply.github.com"
 

--- a/.github/workflows/DrainpipeDev.yml
+++ b/.github/workflows/DrainpipeDev.yml
@@ -36,7 +36,7 @@ jobs:
           git branch -m ${{ github.ref_name }}
           git remote add origin git@github.com:Lullabot/drainpipe-dev.git
           git fetch origin
-          git reset --mixed origin/main
+          git reset --mixed ${{ github.ref_name }} || git reset --mixed origin/main
           git config user.name "Lullabot-Drainpipe[bot]"
           git config user.email "157769597+Lullabot-Drainpipe[bot]@users.noreply.github.com"
 

--- a/drainpipe-dev/.github/workflows/repo-lockdown.yml
+++ b/drainpipe-dev/.github/workflows/repo-lockdown.yml
@@ -6,7 +6,7 @@ on:
   pull_request_target:
     types: opened
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * 1'
 
 permissions:
   issues: write


### PR DESCRIPTION
* Make the checkout fallback to `origin/main` in case the branch or tag doesn't exist. This will support if we want to push more branches to drainpipe-dev in the future for testing or anything.
* Adjust the repo-lockdown workflow to run once a week instead of every hour, we were running into secondary rate limits: https://github.com/Lullabot/drainpipe-dev/actions/runs/8707015439