### PR TITLE
Extract a needs download method in the binary installer

### DIFF
--- a/src/BinaryInstaller.php
+++ b/src/BinaryInstaller.php
@@ -208,7 +208,7 @@ class BinaryInstaller implements PluginInterface, EventSubscriberInterface
 
         // Check the cache.
         $fs->ensureDirectoryExists($cacheFolder);
-        if (!$this->cache->isEnabled() || !file_exists($cacheDestination) || (file_exists($cacheDestination) && hash_file($hashalgo, $cacheDestination) !== $sha)) {
+        if ($this->needsDownload($cacheDestination, $hashalgo, $sha)) {
             // Fetch a new copy of the binary.
             $httpDownloader->copy($url, $cacheDestination);
         } else {
@@ -252,5 +252,18 @@ class BinaryInstaller implements PluginInterface, EventSubscriberInterface
                 chmod($binDestination, 0755);
             }
         }
+    }
+
+    /**
+     * Return if a file needs to be downloaded or not.
+     *
+     * @param string $cacheDestination The destination path to the downloaded file.
+     * @param $hashalgo The hash algorithm used to validate the file.
+     * @param $hash The hash used to validate the file.
+     *
+     * @return bool True if the file needs to be downloaded again, false otherwise.
+     */
+    private function needsDownload(string $cacheDestination, $hashalgo, $hash): bool {
+        return !$this->cache->isEnabled() || !file_exists($cacheDestination) || (file_exists($cacheDestination) && hash_file($hashalgo, $cacheDestination) !== $hash);
     }
 }

--- a/src/BinaryInstaller.php
+++ b/src/BinaryInstaller.php
@@ -264,6 +264,6 @@ class BinaryInstaller implements PluginInterface, EventSubscriberInterface
      * @return bool True if the file needs to be downloaded again, false otherwise.
      */
     private function needsDownload(string $cacheDestination, $hashalgo, $hash): bool {
-        return !$this->cache->isEnabled() || !file_exists($cacheDestination) || (file_exists($cacheDestination) && hash_file($hashalgo, $cacheDestination) !== $hash);
+        return !$this->cache->isEnabled() || !file_exists($cacheDestination) || hash_file($hashalgo, $cacheDestination) !== $hash;
     }
 }


### PR DESCRIPTION
This PR is from https://github.com/Lullabot/drainpipe/pull/114 and:

1. Pulls out a method to document our if logic.
2. We don't need the second file_exists() call. The first one will return if it does not exist, which means to get to the last `||` statement the file must exist.