### PR TITLE
Drop all Drupal 9 dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,10 @@
         "php": "^8.1",
         "ext-json": "*",
         "composer-plugin-api": "^2.0",
-        "drush/drush": "^10|^11|^12",
-        "symfony/yaml": "^3|^4|^5|^6",
-        "twig/twig": "^2|^3",
-        "vlucas/phpdotenv": "^4|^5",
-        "ext-json": "*"
+        "drush/drush": "^11|^12|^13",
+        "symfony/yaml": "^6|^7",
+        "twig/twig": "^3",
+        "vlucas/phpdotenv": "^4|^5"
     },
     "require-dev": {
         "composer/composer": "^2.7.2",


### PR DESCRIPTION
Fixes https://github.com/Lullabot/drainpipe/issues/541

## Changes
* Drops support for Drush v10. Drupal 10 requires at least v11.
* Drops support for Symfony v3, v4, and v5. Drupal 10 requires at least v6.2.
* Drops support for Twig 2. Drupal 10 requires at least v3.
* Adds support for Drush v13.
* Adds support for Symfony v7.
* Fixes that `ext-json` was listed twice.

Once this is merged we can close https://github.com/Lullabot/drainpipe/pull/451 or re-run it.