### PR TITLE
Update drainpipe-dev to remove old Symfony dependency versions

### DIFF
--- a/drainpipe-dev/composer.json
+++ b/drainpipe-dev/composer.json
@@ -21,7 +21,7 @@
         "symfony/phpunit-bridge": "^6|^7",
         "lullabot/drainpipe": "*",
         "mglaman/phpstan-drupal": "^1.2.10",
-        "symfony/yaml": "^3|^4|^5|^6",
+        "symfony/yaml": "^6|^7",
         "drupal/coder": "^8.3.23",
         "behat/mink-browserkit-driver": "^2.2.0",
         "tijsverkoyen/convert-to-junit-xml": "^1.11.0",


### PR DESCRIPTION
https://github.com/Lullabot/drainpipe/pull/544 was still failing widely because I forgot there was a drainpipe-dev dependency that I didn't also update in https://github.com/Lullabot/drainpipe/pull/542