### PR TITLE
Issue #369: Inject environment indicators into DDEV settings

### DIFF
--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -211,6 +211,18 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             $fs = new Filesystem();
             $fs->ensureDirectoryExists('./.ddev/commands/web');
             $fs->copy($ddevCommandPath, './.ddev/commands/web/task');
+            if (file_exists('./web/sites/default/settings.php')) {
+                $settings = file_get_contents('./web/sites/default/settings.php');
+                if (strpos($settings, 'environment-indicator') === false) {
+                    $include = <<<'EOT'
+  // See https://architecture.lullabot.com/adr/20210609-environment-indicator/
+  $config['environment_indicator.indicator']['name'] = 'Local';
+  $config['environment_indicator.indicator']['bg_color'] = '#505050';
+  $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+EOT;
+                    file_put_contents('./web/sites/default/settings.php', $include . PHP_EOL, FILE_APPEND);
+                }
+            }
         }
     }
 

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -211,16 +211,16 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             $fs = new Filesystem();
             $fs->ensureDirectoryExists('./.ddev/commands/web');
             $fs->copy($ddevCommandPath, './.ddev/commands/web/task');
-            if (file_exists('./web/sites/default/settings.php')) {
-                $settings = file_get_contents('./web/sites/default/settings.php');
+            if (file_exists('./web/sites/default/settings.ddev.php')) {
+                $settings = file_get_contents('./web/sites/default/settings.ddev.php');
                 if (strpos($settings, 'environment-indicator') === false) {
                     $include = <<<'EOT'
-  // See https://architecture.lullabot.com/adr/20210609-environment-indicator/
-  $config['environment_indicator.indicator']['name'] = 'Local';
-  $config['environment_indicator.indicator']['bg_color'] = '#505050';
-  $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+// See https://architecture.lullabot.com/adr/20210609-environment-indicator/
+$config['environment_indicator.indicator']['name'] = 'Local';
+$config['environment_indicator.indicator']['bg_color'] = '#505050';
+$config['environment_indicator.indicator']['fg_color'] = '#ffffff';
 EOT;
-                    file_put_contents('./web/sites/default/settings.php', $include . PHP_EOL, FILE_APPEND);
+                    file_put_contents('./web/sites/default/settings.ddev.php', $include . PHP_EOL, FILE_APPEND);
                 }
             }
         }


### PR DESCRIPTION
Fixes #369 

* Adds a way for environment indicator settings to be injected into ddev.
Not sure if this is the best approach but I followed how settings.php gets changed to include tugboat. I decided against generating a different settings.*.php file for ddev because I couldn't see a clean way to include it when needed and exclude it when its not.