### PR TITLE
Separate test:security task out from test:static

### DIFF
--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -61,11 +61,11 @@ jobs:
         run: |
           sed -i '/^.*container_yamls.*$/i /** @phpstan-ignore-next-line */' web/sites/default/settings.php
 
-      - name: Run Security Tests
+      - name: Run security tests (only on scheduled runs)
         if: ${{ github.event_name == 'schedule' }}
         run: ddev task test:security
 
-      - name: Run Static Tests
+      - name: Run static tests
         run: ddev task test:static
 
       - name: Confirm custom directories are scanned

--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -61,12 +61,12 @@ jobs:
         run: |
           sed -i '/^.*container_yamls.*$/i /** @phpstan-ignore-next-line */' web/sites/default/settings.php
 
-      - name: Run Static Tests
-        run: ddev task test:static
-
       - name: Run Security Tests
         if: ${{ github.event_name == 'schedule' }}
         run: ddev task test:security
+
+      - name: Run Static Tests
+        run: ddev task test:static
 
       - name: Confirm custom directories are scanned
         run: |

--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '0 0 * * *'
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -60,6 +63,10 @@ jobs:
 
       - name: Run Static Tests
         run: ddev task test:static
+
+      - name: Run Security Tests
+        if: ${{ github.event_name == 'schedule' }}
+        run: ddev task test:security
 
       - name: Confirm custom directories are scanned
         run: |

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -17,7 +17,7 @@ vars:
 tasks:
   static:
     desc: Runs all static tests
-    deps: [security, lint, phpstan, phpunit:static, phpcs]
+    deps: [lint, phpstan, phpunit:static, phpcs]
   functional:
     desc: Runs all tests that require a bootstrapped Drupal site
     deps: [config, phpunit:functional, nightwatch]


### PR DESCRIPTION
Fixes https://github.com/Lullabot/drainpipe/issues/112

How this affects consumers:

* Running `task test:static` will no longer run the `test:security` task by default.
* No scaffolded workflow changes

How this affects Drainpipe
* Adds a scheduled workflow for running the [_Test Static Tests_ workflow](https://github.com/Lullabot/drainpipe/actions/workflows/TestStatic.yml) day that will include the `task test:security` command as a best example.