### PR TITLE
WIP Renovate/php 8.x  luisaveiga

### DIFF
--- a/.github/workflows/TestBinaryInstaller.yml
+++ b/.github/workflows/TestBinaryInstaller.yml
@@ -33,6 +33,7 @@ jobs:
           composer-cache-dir: composer-cache
           git-name: Drainpipe Bot
           git-email: no-reply@example.com
+          version: '1.23.2'
 
       - name: Setup Project
         run: |

--- a/.github/workflows/TestBinaryInstaller.yml
+++ b/.github/workflows/TestBinaryInstaller.yml
@@ -33,7 +33,6 @@ jobs:
           composer-cache-dir: composer-cache
           git-name: Drainpipe Bot
           git-email: no-reply@example.com
-          version: '1.23.2'
 
       - name: Setup Project
         run: |

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           echo "api_version: 1" >> pantheon.yml
           echo "web_docroot: true" >> pantheon.yml
-          echo "php_version: 8.1" >> pantheon.yml
+          echo "php_version: 8.3" >> pantheon.yml
           echo "drush_version: 10" >> pantheon.yml
           echo "database:" >> pantheon.yml
           echo "  version: 10.4" >> pantheon.yml

--- a/.github/workflows/composer-plugin.yml
+++ b/.github/workflows/composer-plugin.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3]
+        php-version: [8.3]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-production-build.yml
+++ b/.github/workflows/test-production-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3]
+        php-version: [8.3]
 
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "psr-4": {"Lullabot\\Drainpipe\\Tests\\Functional\\": "tests/src/functional/"}
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.3.8",
         "ext-json": "*",
         "composer-plugin-api": "^2.0",
         "drush/drush": "^11|^12|^13",

--- a/drainpipe-dev/composer.json
+++ b/drainpipe-dev/composer.json
@@ -10,7 +10,7 @@
         "psr-4": {"Lullabot\\DrainpipeDev\\Tests\\Functional\\": "tests/src/functional/"}
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.3.8",
         "ext-json": "*",
         "composer-plugin-api": "^2.0",
         "phpunit/phpunit": "^9.6.19",

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -19,6 +19,7 @@ inputs:
   version:
     description: "Override the DDEV version .e.g. '1.19.0'"
     required: false
+    default: "1.23.2"
 runs:
   using: "composite"
   steps:

--- a/scaffold/github/actions/pantheon/review/action.yml
+++ b/scaffold/github/actions/pantheon/review/action.yml
@@ -90,6 +90,7 @@ runs:
           drainpipe_exec "terminus env:wipe ${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER --yes"
         else
           drainpipe_exec "terminus multidev:create ${{ inputs.site-name }}.live pr-$DRAINPIPE_PR_NUMBER --no-db --no-files --yes"
+          drainpipe_exec "terminus env:php-version:set ${{ inputs.site-name }}.live 8.3"
         fi
         if [ "${{ inputs.run-installer }}" != "true" ]; then
             drainpipe_exec "terminus env:clone-content ${{ inputs.site-name }}.live pr-$DRAINPIPE_PR_NUMBER --yes"

--- a/scaffold/github/actions/pantheon/review/action.yml
+++ b/scaffold/github/actions/pantheon/review/action.yml
@@ -90,7 +90,6 @@ runs:
           drainpipe_exec "terminus env:wipe ${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER --yes"
         else
           drainpipe_exec "terminus multidev:create ${{ inputs.site-name }}.live pr-$DRAINPIPE_PR_NUMBER --no-db --no-files --yes"
-          drainpipe_exec "terminus env:php-version:set ${{ inputs.site-name }}.live 8.3"
         fi
         if [ "${{ inputs.run-installer }}" != "true" ]; then
             drainpipe_exec "terminus env:clone-content ${{ inputs.site-name }}.live pr-$DRAINPIPE_PR_NUMBER --yes"
@@ -109,7 +108,7 @@ runs:
       run: |
         source .github/actions/drainpipe/set-env/bash_aliases
         drainpipe_exec "terminus workflow:wait ${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER"
-
+        drainpipe_exec "terminus env:php-version:set ${{ inputs.site-name }}.live 8.3"
         drainpipe_exec "terminus aliases --only ${{ inputs.site-name }} --yes"
         if [ "${{ inputs.run-installer }}" == "true" ]; then
           drainpipe_exec "./vendor/bin/drush @${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER --yes site:install --existing-config"

--- a/scaffold/github/actions/pantheon/review/action.yml
+++ b/scaffold/github/actions/pantheon/review/action.yml
@@ -108,7 +108,6 @@ runs:
       run: |
         source .github/actions/drainpipe/set-env/bash_aliases
         drainpipe_exec "terminus workflow:wait ${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER"
-        drainpipe_exec "terminus env:php-version:set ${{ inputs.site-name }}.live 8.3"
         drainpipe_exec "terminus aliases --only ${{ inputs.site-name }} --yes"
         if [ "${{ inputs.run-installer }}" == "true" ]; then
           drainpipe_exec "./vendor/bin/drush @${{ inputs.site-name }}.pr-$DRAINPIPE_PR_NUMBER --yes site:install --existing-config"


### PR DESCRIPTION
## Description
This PR is a modification of #588 

## Background
The tugboat is not working. If I recall correctly, I saw a quota issue explaining why the tests are failing.

Do you know if this is what is needed? I added restrictions to run tests with PHP 8.3 only.
I also set the default DDEV version to 1.23.2 because I couldn't replicate the issues on my machine when I started. DDEV v1.23.2 already has PHP 8.3.

There are PHP version strings on the Drainpipe Tugboat still, but I prefer to first have feedback if this is the correct approach. If so, I can update the missing ones.


