### PR TITLE
Issue #605: Pin Drupal version on Tugboat

### DIFF
--- a/.tugboat/steps/1-init.sh
+++ b/.tugboat/steps/1-init.sh
@@ -74,7 +74,7 @@ nodejs -v | grep -q v$NODE_MAJOR
 shopt -s dotglob
 mkdir ../drainpipe-tmp
 mv * ../drainpipe-tmp/
-composer create-project drupal/recommended-project:~10.2 .
+composer create-project drupal/recommended-project:10.2.7 .
 mv ../drainpipe-tmp drainpipe
 composer config extra.drupal-scaffold.gitignore true
 composer config --json extra.drupal-scaffold.allowed-packages \[\"lullabot/drainpipe\"]

--- a/.tugboat/steps/1-init.sh
+++ b/.tugboat/steps/1-init.sh
@@ -74,7 +74,7 @@ nodejs -v | grep -q v$NODE_MAJOR
 shopt -s dotglob
 mkdir ../drainpipe-tmp
 mv * ../drainpipe-tmp/
-composer create-project drupal/recommended-project .
+composer create-project drupal/recommended-project:~10.2 .
 mv ../drainpipe-tmp drainpipe
 composer config extra.drupal-scaffold.gitignore true
 composer config --json extra.drupal-scaffold.allowed-packages \[\"lullabot/drainpipe\"]

--- a/.tugboat/steps/1-init.sh
+++ b/.tugboat/steps/1-init.sh
@@ -74,7 +74,7 @@ nodejs -v | grep -q v$NODE_MAJOR
 shopt -s dotglob
 mkdir ../drainpipe-tmp
 mv * ../drainpipe-tmp/
-composer create-project drupal/recommended-project:10.2.7 .
+composer create-project drupal/recommended-project:~10.2.7 .
 mv ../drainpipe-tmp drainpipe
 composer config extra.drupal-scaffold.gitignore true
 composer config --json extra.drupal-scaffold.allowed-packages \[\"lullabot/drainpipe\"]


### PR DESCRIPTION
fixes: #605 

Tugboat builds for Drainpipe have been failing ever since Drupal 10.3.x was released.
Upon investigation it showed that the [sessions table is no longer part of install schema](https://www.drupal.org/node/3431286) and because of that `drush sql:sanitize` fails. This [has been fixed in Drush 13](https://github.com/drush-ops/drush/blob/13.x/src/Commands/sql/sanitize/SanitizeSessionsCommands.php) and is awaiting a stable release, it will also be [backported to Drush 12](https://github.com/drush-ops/drush/issues/6041).

To unblock all Drainpipe work until this gets fixed upstream I propose we pin Tugboat builds for Drainpipe to Drupal 10.2.7.
