### PR TITLE
Issue #638: Fix all our tests

### DIFF
--- a/.github/workflows/TestBinaryInstaller.yml
+++ b/.github/workflows/TestBinaryInstaller.yml
@@ -13,10 +13,18 @@ concurrency:
 jobs:
   Test-Binary-Installer:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        php-version: [ 8.1, 8.2, 8.3 ]
+        include:
+          - php-version: 8.1
+            drupal-version: ":^10"
+          - php-version: 8.2
+            drupal-version: ":^10"
     steps:
 
       - name: Create a Drupal project
-        run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+        run: composer create-project drupal/recommended-project${{ matrix.drupal-version }} . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:
@@ -37,6 +45,7 @@ jobs:
       - name: Setup Project
         run: |
           ddev config --auto
+          ddev config --php-version ${{ matrix.php-version }}
           ddev start
           ddev composer config extra.drupal-scaffold.gitignore true
           ddev composer config --json extra.drupal-scaffold.allowed-packages '["lullabot/drainpipe-dev", "lullabot/drainpipe"]'

--- a/.github/workflows/TestComposerLockDiff.yml
+++ b/.github/workflows/TestComposerLockDiff.yml
@@ -11,9 +11,12 @@ concurrency:
 jobs:
   Test-Composer-Lock-Diff:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - name: Create a Drupal project
-        run: composer create-project drupal/recommended-project:10.0.9 . --ignore-platform-req=ext-gd
+        run: composer create-project drupal/recommended-project:^${{ matrix.drupal-version }} . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/TestComposerLockDiff.yml
+++ b/.github/workflows/TestComposerLockDiff.yml
@@ -80,7 +80,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: processed-descriptions
+          name: processed-descriptions-${{ matrix.drupal-version }}
           path: |
             renovate-processed.json
             pr-template-processed.json

--- a/.github/workflows/TestDDEV.yml
+++ b/.github/workflows/TestDDEV.yml
@@ -13,9 +13,12 @@ concurrency:
 jobs:
   Test-DDEV-Install:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - name: Create a Drupal project
-        run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+        run: composer create-project drupal/recommended-project:^${{ matrix.drupal-version }} . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:
@@ -35,7 +38,6 @@ jobs:
       - name: Setup Project
         run: |
           ddev config --auto
-          ddev config --nodejs-version "18"
           ddev start
           ddev composer config extra.drupal-scaffold.gitignore true
           ddev composer config --json extra.drupal-scaffold.allowed-packages '["lullabot/drainpipe-dev", "lullabot/drainpipe"]'

--- a/.github/workflows/TestEnv.yml
+++ b/.github/workflows/TestEnv.yml
@@ -11,10 +11,13 @@ concurrency:
 jobs:
   Test-Env:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - name: Create a Drupal project
         run: |
-          composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+          composer create-project drupal/recommended-project:^${{ matrix.drupal-version }} . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Setup Project
         run: |
           ddev config --auto
-          ddev config --nodejs-version "18"
+          ddev config --nodejs-version "22"
+          ddev config --corepack-enable
           ddev start
           ddev composer config extra.drupal-scaffold.gitignore true
           ddev composer config --json extra.drupal-scaffold.allowed-packages '["lullabot/drainpipe-dev", "lullabot/drainpipe"]'
@@ -143,7 +144,9 @@ jobs:
 
       - name: Setup Nightwatch
         run: |
-          ddev yarn set version classic
+          ddev exec corepack disable
+          ddev exec npm i -g yarn@1.22.1
+          ddev exec 'ln -s $(npm root -g)/yarn/bin/yarn /usr/local/bin/yarn'
           ddev yarn init -y
           ddev yarn add nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands lodash --dev
 

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -68,16 +68,19 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
           path: /tmp/drainpipe.zip
 
   Test-NPM:
     runs-on: ubuntu-22.04
     needs: Build
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -122,10 +125,13 @@ jobs:
   Test-Yarn-Classic:
     runs-on: ubuntu-22.04
     needs: Build
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -173,10 +179,13 @@ jobs:
   Test-Yarn-3-Node-Linker:
     runs-on: ubuntu-22.04
     needs: Build
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -224,10 +233,13 @@ jobs:
   Test-Yarn-4-Node-Linker:
     runs-on: ubuntu-22.04
     needs: Build
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -276,10 +288,13 @@ jobs:
   Test-Yarn-3:
     runs-on: ubuntu-22.04
     needs: Build
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -330,6 +345,9 @@ jobs:
   Test-Yarn-4:
     runs-on: ubuntu-22.04
     needs: Build
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
           path: /tmp/drainpipe.zip
 
   Test-NPM:
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -125,7 +125,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -176,7 +176,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -227,7 +227,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -279,7 +279,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |
@@ -333,7 +333,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build
+          name: test-functional-build-${{ matrix.drupal-version }}
 
       - name: Restore Workspace
         run: |

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -245,6 +245,9 @@ jobs:
       - name: Start DDEV
         run: ddev start
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Setup Nightwatch
         run: |
           ddev exec corepack enable

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -119,7 +119,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result-npm
+          name: test_result-npm-${{ matrix.drupal-version }}
           path: test_result
 
   Test-Yarn-Classic:
@@ -173,7 +173,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result-yarn-classic
+          name: test_result-yarn-classic-${{ matrix.drupal-version }}
           path: test_result
 
   Test-Yarn-3-Node-Linker:
@@ -227,7 +227,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result-yarn3-nl
+          name: test_result-yarn3-nl-${{ matrix.drupal-version }}
           path: test_result
 
   Test-Yarn-4-Node-Linker:
@@ -282,7 +282,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result-yarn4-nl
+          name: test_result-yarn4-nl-${{ matrix.drupal-version }}
           path: test_result
 
   Test-Yarn-3:
@@ -339,7 +339,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result-yarn3
+          name: test_result-yarn3-${{ matrix.drupal-version }}
           path: test_result
 
   Test-Yarn-4:
@@ -397,5 +397,5 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result-yarn4
+          name: test_result-yarn4-${{ matrix.drupal-version }}
           path: test_result

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -195,11 +195,10 @@ jobs:
 
       - name: Setup Nightwatch
         run: |
-          ddev exec corepack enable
           ddev yarn set version berry
           ddev yarn set version 3
           ddev yarn init -y
-          yarn config set nodeLinker node-modules
+          ddev yarn config set nodeLinker node-modules
           ddev yarn add nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands lodash --dev
 
       - name: Install Drupal
@@ -245,17 +244,13 @@ jobs:
       - name: Start DDEV
         run: ddev start
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Setup Nightwatch
         run: |
-          ddev exec corepack enable
           ddev restart
           ddev yarn set version berry
           ddev yarn set version 4
           ddev yarn init -y
-          yarn config set nodeLinker node-modules
+          ddev yarn config set nodeLinker node-modules
           ddev yarn add nightwatch nightwatch-accessibility @lullabot/nightwatch-drupal-commands lodash --dev
 
       - name: Install Drupal

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -195,6 +195,7 @@ jobs:
 
       - name: Setup Nightwatch
         run: |
+          ddev exec corepack enable
           ddev yarn set version berry
           ddev yarn set version 3
           ddev yarn init -y
@@ -246,7 +247,7 @@ jobs:
 
       - name: Setup Nightwatch
         run: |
-          ddev config --nodejs-version=21
+          ddev exec corepack enable
           ddev restart
           ddev yarn set version berry
           ddev yarn set version 4
@@ -353,7 +354,6 @@ jobs:
 
       - name: Setup Nightwatch
         run: |
-          ddev config --nodejs-version=21
           ddev restart
           ddev yarn set version berry
           ddev yarn init -y

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -13,9 +13,12 @@ concurrency:
 jobs:
   Build:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - name: Create a Drupal project
-        run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+        run: composer create-project drupal/recommended-project:^${{ matrix.drupal-version }} . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/TestFunctional.yml
+++ b/.github/workflows/TestFunctional.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: test-functional-build-${{ matrix.drupal-version }}
+          name: test-functional-build
           path: /tmp/drainpipe.zip
 
   Test-NPM:
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build-${{ matrix.drupal-version }}
+          name: test-functional-build
 
       - name: Restore Workspace
         run: |
@@ -125,7 +125,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build-${{ matrix.drupal-version }}
+          name: test-functional-build
 
       - name: Restore Workspace
         run: |
@@ -176,7 +176,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build-${{ matrix.drupal-version }}
+          name: test-functional-build
 
       - name: Restore Workspace
         run: |
@@ -227,7 +227,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build-${{ matrix.drupal-version }}
+          name: test-functional-build
 
       - name: Restore Workspace
         run: |
@@ -279,7 +279,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: test-functional-build-${{ matrix.drupal-version }}
+          name: test-functional-build
 
       - name: Restore Workspace
         run: |

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -59,7 +59,6 @@ jobs:
           echo "api_version: 1" >> pantheon.yml
           echo "web_docroot: true" >> pantheon.yml
           echo "php_version: 8.3" >> pantheon.yml
-          echo "drush_version: 13" >> pantheon.yml
           echo "database:" >> pantheon.yml
           echo "  version: 10.6" >> pantheon.yml
           echo "enforce_https: full+subdomains" >> pantheon.yml

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -77,7 +77,7 @@ jobs:
           echo "\$settings['container_yamls'][] = __DIR__ . '/services.yml';" >> web/sites/default/settings.php
           echo "include __DIR__ . \"/settings.pantheon.php\";" >> web/sites/default/settings.php
           echo "\$settings['config_sync_directory'] = '../config';" >> web/sites/default/settings.php
-          curl -o web/sites/default/settings.pantheon.phphttps://raw.githubusercontent.com/pantheon-systems/drupal-integrations/11.x/assets/settings.pantheon.php
+          curl -o web/sites/default/settings.pantheon.php https://raw.githubusercontent.com/pantheon-systems/drupal-integrations/11.x/assets/settings.pantheon.php
 
       - name: Snapshot Project
         env:

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -59,9 +59,9 @@ jobs:
           echo "api_version: 1" >> pantheon.yml
           echo "web_docroot: true" >> pantheon.yml
           echo "php_version: 8.3" >> pantheon.yml
-          echo "drush_version: 10" >> pantheon.yml
+          echo "drush_version: 13" >> pantheon.yml
           echo "database:" >> pantheon.yml
-          echo "  version: 10.4" >> pantheon.yml
+          echo "  version: 10.6" >> pantheon.yml
           echo "enforce_https: full+subdomains" >> pantheon.yml
           echo "build_step: false" >> pantheon.yml
 

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -77,7 +77,7 @@ jobs:
           echo "\$settings['container_yamls'][] = __DIR__ . '/services.yml';" >> web/sites/default/settings.php
           echo "include __DIR__ . \"/settings.pantheon.php\";" >> web/sites/default/settings.php
           echo "\$settings['config_sync_directory'] = '../config';" >> web/sites/default/settings.php
-          curl -o web/sites/default/settings.pantheon.php https://raw.githubusercontent.com/pantheon-systems/drops-8/default/sites/default/settings.pantheon.php
+          curl -o web/sites/default/settings.pantheon.phphttps://raw.githubusercontent.com/pantheon-systems/drupal-integrations/11.x/assets/settings.pantheon.php
 
       - name: Snapshot Project
         env:

--- a/.github/workflows/TestGitHubActions.yml
+++ b/.github/workflows/TestGitHubActions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Create a Drupal project
-        run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+        run: composer create-project drupal/recommended-project . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:
@@ -58,7 +58,7 @@ jobs:
         run: |
           echo "api_version: 1" >> pantheon.yml
           echo "web_docroot: true" >> pantheon.yml
-          echo "php_version: 8.1" >> pantheon.yml
+          echo "php_version: 8.3" >> pantheon.yml
           echo "drush_version: 10" >> pantheon.yml
           echo "database:" >> pantheon.yml
           echo "  version: 10.4" >> pantheon.yml

--- a/.github/workflows/TestMetapackages.yml
+++ b/.github/workflows/TestMetapackages.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Create a Drupal project
-        run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+        run: composer create-project drupal/recommended-project . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Project
         run: |
           ddev config --auto
-          ddev config --nodejs-version "18"
+          ddev config --nodejs-version "22"
           ddev start
           ddev composer config extra.drupal-scaffold.gitignore true
           ddev composer config --json extra.drupal-scaffold.allowed-packages '["lullabot/drainpipe-dev", "lullabot/drainpipe"]'
@@ -197,7 +197,6 @@ jobs:
 
       - name: Setup Sass
         run: |
-          ddev config --nodejs-version=21
           ddev restart
           ddev yarn set version berry
           ddev yarn set version 4
@@ -344,7 +343,6 @@ jobs:
 
       - name: Setup Sass
         run: |
-          ddev config --nodejs-version=21
           ddev restart
           ddev yarn set version berry
           ddev yarn set version 4

--- a/.github/workflows/TestMetapackages.yml
+++ b/.github/workflows/TestMetapackages.yml
@@ -129,6 +129,7 @@ jobs:
         run: |
           ddev exec corepack disable
           ddev exec npm i -g yarn@1.22.1
+          ddev exec 'ln -s $(npm root -g)/yarn/bin/yarn /usr/local/bin/yarn'
           ddev exec yarn init -y
           ddev exec yarn add file:./drainpipe/metapackages/sass --dev
 
@@ -274,6 +275,7 @@ jobs:
         run: |
           ddev exec corepack disable
           ddev exec npm i -g yarn@1.22.1
+          ddev exec 'ln -s $(npm root -g)/yarn/bin/yarn /usr/local/bin/yarn'
           ddev exec yarn init -y
           ddev exec yarn add focus-trap@^6.7.3
           ddev exec yarn add file:./drainpipe/metapackages/javascript --dev

--- a/.github/workflows/TestMetapackages.yml
+++ b/.github/workflows/TestMetapackages.yml
@@ -270,9 +270,6 @@ jobs:
       - name: Start DDEV
         run: ddev start
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Setup Sass
         run: |
           ddev exec corepack disable

--- a/.github/workflows/TestMetapackages.yml
+++ b/.github/workflows/TestMetapackages.yml
@@ -270,6 +270,9 @@ jobs:
       - name: Start DDEV
         run: ddev start
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Setup Sass
         run: |
           ddev yarn set version classic

--- a/.github/workflows/TestMetapackages.yml
+++ b/.github/workflows/TestMetapackages.yml
@@ -127,8 +127,8 @@ jobs:
 
       - name: Setup Sass
         run: |
-          ddev yarn set version classic
-          ddev yarn set version 1
+          ddev exec corepack disable
+          ddev exec npm i -g yarn@1.22.1
           ddev yarn init -y
           ddev yarn add file:./drainpipe/metapackages/sass --dev
 
@@ -275,8 +275,8 @@ jobs:
 
       - name: Setup Sass
         run: |
-          ddev yarn set version classic
-          ddev yarn set version 1
+          ddev exec corepack disable
+          ddev exec npm i -g yarn@1.22.1
           ddev yarn init -y
           ddev yarn add focus-trap@^6.7.3
           ddev yarn add file:./drainpipe/metapackages/javascript --dev

--- a/.github/workflows/TestMetapackages.yml
+++ b/.github/workflows/TestMetapackages.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           ddev config --auto
           ddev config --nodejs-version "22"
+          ddev config --corepack-enable
           ddev start
           ddev composer config extra.drupal-scaffold.gitignore true
           ddev composer config --json extra.drupal-scaffold.allowed-packages '["lullabot/drainpipe-dev", "lullabot/drainpipe"]'

--- a/.github/workflows/TestMetapackages.yml
+++ b/.github/workflows/TestMetapackages.yml
@@ -129,8 +129,8 @@ jobs:
         run: |
           ddev exec corepack disable
           ddev exec npm i -g yarn@1.22.1
-          ddev yarn init -y
-          ddev yarn add file:./drainpipe/metapackages/sass --dev
+          ddev exec yarn init -y
+          ddev exec yarn add file:./drainpipe/metapackages/sass --dev
 
       - name: Compile Sass
         run: ddev task sass
@@ -274,9 +274,9 @@ jobs:
         run: |
           ddev exec corepack disable
           ddev exec npm i -g yarn@1.22.1
-          ddev yarn init -y
-          ddev yarn add focus-trap@^6.7.3
-          ddev yarn add file:./drainpipe/metapackages/javascript --dev
+          ddev exec yarn init -y
+          ddev exec yarn add focus-trap@^6.7.3
+          ddev exec yarn add file:./drainpipe/metapackages/javascript --dev
 
       - name: Compile JavaScript
         run: ddev task javascript

--- a/.github/workflows/TestMetapackages.yml
+++ b/.github/workflows/TestMetapackages.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Setup Sass
         run: |
           ddev yarn set version classic
+          ddev yarn set version 1
           ddev yarn init -y
           ddev yarn add file:./drainpipe/metapackages/sass --dev
 
@@ -271,6 +272,7 @@ jobs:
       - name: Setup Sass
         run: |
           ddev yarn set version classic
+          ddev yarn set version 1
           ddev yarn init -y
           ddev yarn add focus-trap@^6.7.3
           ddev yarn add file:./drainpipe/metapackages/javascript --dev

--- a/.github/workflows/TestPHPUnit.yml
+++ b/.github/workflows/TestPHPUnit.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result-phpunit-functional
+          name: test_result-phpunit-functional-${{ matrix.drupal-version }}
           path: test_result
 
       - name: Confirm All PHPUnit Functional Tests were run
@@ -86,6 +86,9 @@ jobs:
 
   Test-PHPUnit-Functional-DTT:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - name: Install xmllint
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
@@ -143,7 +146,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result-phpunit-dtt
+          name: test_result-phpunit-dtt-${{ matrix.drupal-version }}
           path: test_result
 
       - name: Confirm All PHPUnit Functional Tests were run
@@ -155,6 +158,9 @@ jobs:
 
   Test-PHPUnit-Static:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - name: Install xmllint
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
@@ -208,7 +214,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_result-phpunit-static
+          name: test_result-phpunit-static-${{ matrix.drupal-version }}
           path: test_result
 
       - name: Confirm All PHPUnit Functional Tests were run

--- a/.github/workflows/TestPHPUnit.yml
+++ b/.github/workflows/TestPHPUnit.yml
@@ -78,7 +78,7 @@ jobs:
         uses: GuillaumeFalourd/assert-command-line-output@v2.3
         with:
           command_line: xmllint --xpath 'string(//testsuites/testsuite/@tests)' test_result/phpunit-functional.xml
-          contains: 18
+          contains: 6
           expected_result: PASSED
 
   Test-PHPUnit-Functional-DTT:
@@ -147,7 +147,7 @@ jobs:
         uses: GuillaumeFalourd/assert-command-line-output@v2
         with:
           command_line: xmllint --xpath 'string(//testsuites/testsuite/@tests)' test_result/phpunit-functional.xml
-          contains: 21
+          contains: 9
           expected_result: PASSED
 
   Test-PHPUnit-Static:

--- a/.github/workflows/TestPHPUnit.yml
+++ b/.github/workflows/TestPHPUnit.yml
@@ -13,12 +13,15 @@ concurrency:
 jobs:
   Test-PHPUnit-Functional:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - name: Install xmllint
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
 
       - name: Create a Drupal project
-        run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+        run: composer create-project drupal/recommended-project:^${{ matrix.drupal-version }} . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/TestStatic.yml
+++ b/.github/workflows/TestStatic.yml
@@ -13,9 +13,12 @@ concurrency:
 jobs:
   Test-Static:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        drupal-version: [ 10, 11 ]
     steps:
       - name: Create a Drupal project
-        run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+        run: composer create-project drupal/recommended-project:^${{ matrix.drupal-version }} . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/TestTugboat.yml
+++ b/.github/workflows/TestTugboat.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Create a Drupal project
-        run: composer create-project drupal/recommended-project . --ignore-platform-req=ext-gd
+        run: composer create-project drupal/recommended-project . --ignore-platform-reqs
 
       - uses: actions/checkout@v4
         with:
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Project
         run: |
           ddev config --auto
-          ddev config --php-version "8.1"
+          ddev config --php-version "8.3"
           ddev config --nodejs-version "18"
           ddev get ddev/ddev-redis --version v1.2.0
           ddev get ddev/ddev-elasticsearch --version v0.3.2
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Project
         run: |
           ddev config --auto
-          ddev config --php-version "8.1"
+          ddev config --php-version "8.3"
           ddev config --nodejs-version "16"
           ddev restart
           ddev composer config extra.drupal-scaffold.gitignore true

--- a/.github/workflows/composer-plugin.yml
+++ b/.github/workflows/composer-plugin.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3]
+        php-version: [ 8.1, 8.2, 8.3 ]
     steps:
       - uses: actions/checkout@v4
 
@@ -36,4 +36,5 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - run: composer install
+
       - run: ./vendor/bin/phpunit

--- a/.github/workflows/test-production-build.yml
+++ b/.github/workflows/test-production-build.yml
@@ -12,7 +12,11 @@ jobs:
     strategy:
       matrix:
         php-version: [8.1, 8.2, 8.3]
-
+        include:
+          - php-version: 8.1
+            drupal-version: ":^10"
+          - php-version: 8.2
+            drupal-version: ":^10"
     steps:
       - uses: actions/checkout@v4
 
@@ -37,7 +41,7 @@ jobs:
       - name: Install Drupal
         run: |
           cd ../
-          composer create-project drupal/recommended-project drupal --ignore-platform-req=ext-gd
+          composer create-project drupal/recommended-project${{ matrix.drupal-version }} drupal --ignore-platform-reqs
           cd drupal
           cp ${GITHUB_WORKSPACE}/tests/fixtures.drainpipe-test-build/Taskfile.yml .
           composer config extra.drupal-scaffold.gitignore true

--- a/.github/workflows/test-production-build.yml
+++ b/.github/workflows/test-production-build.yml
@@ -6,12 +6,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   Test-Production-Build:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3]
+        php-version: [ 8.1, 8.2, 8.3 ]
         include:
           - php-version: 8.1
             drupal-version: ":^10"

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -11,7 +11,7 @@
 services:
   php:
     http: false
-    image: tugboatqa/php-nginx:8.1-fpm
+    image: tugboatqa/php-nginx:8.3-fpm
     default: true
 
     depends:

--- a/drainpipe-dev/composer.json
+++ b/drainpipe-dev/composer.json
@@ -13,20 +13,20 @@
         "php": "^8.1",
         "ext-json": "*",
         "composer-plugin-api": "^2.0",
-        "phpunit/phpunit": "^9.6.20",
-        "sserbin/twig-linter": "^3.1.0",
-        "mikey179/vfsstream": "^1.6.11",
-        "mockery/mockery": "^1.6.12",
         "behat/mink": "^1.11.0",
-        "symfony/phpunit-bridge": "^6|^7",
+        "behat/mink-browserkit-driver": "^2.2.0",
+        "drupal/coder": "^8.3.24",
         "lullabot/drainpipe": "*",
         "mglaman/phpstan-drupal": "^1.2.11",
-        "symfony/yaml": "^6|^7",
-        "drupal/coder": "^8.3.24",
-        "behat/mink-browserkit-driver": "^2.2.0",
-        "tijsverkoyen/convert-to-junit-xml": "^1.11.0",
+        "mikey179/vfsstream": "^1.6.11",
+        "mockery/mockery": "^1.6.12",
+        "phpspec/prophecy-phpunit": "^2",
         "phpstan/phpstan-deprecation-rules": "^1.2.0",
-        "phpspec/prophecy-phpunit": "^2"
+        "phpunit/phpunit": "^9|^10",
+        "symfony/phpunit-bridge": "^6|^7",
+        "symfony/yaml": "^6|^7",
+        "tijsverkoyen/convert-to-junit-xml": "^1.11.0",
+        "vincentlanglet/twig-cs-fixer": "^3.0.0"
     },
     "require-dev": {
         "composer/composer": "^2.7.7"
@@ -49,7 +49,8 @@
                 "[project-root]/.ddev/docker-compose.selenium.yaml": "scaffold/nightwatch/docker-compose.selenium.yaml",
                 "[project-root]/test/nightwatch/example.nightwatch.js": "scaffold/nightwatch/example.nightwatch.js",
                 "[project-root]/phpcs.xml.dist": "scaffold/phpcs.xml.dist",
-                "[project-root]/phpstan.neon.dist": "scaffold/phpstan.neon.dist"
+                "[project-root]/phpstan.neon.dist": "scaffold/phpstan.neon.dist",
+                "[project-root]/.twig-cs-fixer.dist.php": "scaffold/.twig-cs-fixer.dist.php"
             }
         }
     },

--- a/drainpipe-dev/scaffold/.twig-cs-fixer.dist.php
+++ b/drainpipe-dev/scaffold/.twig-cs-fixer.dist.php
@@ -5,7 +5,6 @@ if (PHP_SAPI !== 'cli') {
   return;
 }
 
-print_r(__DIR__);
 if (is_file(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
 }

--- a/drainpipe-dev/scaffold/.twig-cs-fixer.dist.php
+++ b/drainpipe-dev/scaffold/.twig-cs-fixer.dist.php
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 declare(strict_types=1);
 
@@ -6,8 +5,9 @@ if (PHP_SAPI !== 'cli') {
   return;
 }
 
-if (is_file(__DIR__ . '/../../../autoload.php')) {
-    require_once __DIR__ . '/../../../autoload.php';
+print_r(__DIR__);
+if (is_file(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
 }
 else {
     echo "Composer autoload file not found.\n";
@@ -20,21 +20,22 @@ use Drupal\Core\File\FileUrlGenerator;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Core\Theme\ThemeManagerInterface;
-use Symfony\Component\Console\Application;
-use Twig\Loader\ArrayLoader;
-use PackageVersions\Versions;
-
-use Sserbin\TwigLinter\StubEnvironment;
 use Drupal\Core\Template\TwigExtension;
-use Sserbin\TwigLinter\Command\LintCommand;
-
-$twig = new StubEnvironment(new ArrayLoader, []);
 
 $renderer = Mockery::mock(RendererInterface::class);
 $urlGenerator = Mockery::mock(UrlGeneratorInterface::class);
 $themeManager = Mockery::mock(ThemeManagerInterface::class);
 $dateFormatter = Mockery::mock(DateFormatterInterface::class);
 $fileUrlGenerator = Mockery::mock(FileUrlGenerator::class);
+
+$ruleset = new TwigCsFixer\Ruleset\Ruleset();
+
+// default standard.
+$ruleset->addStandard(new TwigCsFixer\Standard\TwigCsFixer());
+
+$config = new TwigCsFixer\Config\Config();
+$config->setRuleset($ruleset);
+$config->addTwigExtension(new TwigExtension($renderer, $urlGenerator, $themeManager, $dateFormatter, $fileUrlGenerator));
 
 if (class_exists('\TwigStorybook\Twig\TwigExtension')) {
   $composer_json = json_decode(file_get_contents(__DIR__ . '/../../../../composer.json'), true);
@@ -43,14 +44,7 @@ if (class_exists('\TwigStorybook\Twig\TwigExtension')) {
   }
 
   $web_root = $composer_json['extra']['drupal-scaffold']['locations']['web-root'];
-  $twig->addExtension(new \TwigStorybook\Twig\TwigExtension(new \TwigStorybook\Service\StoryCollector(), '/../../../../' . $web_root));
+  $config->addExtension(new \TwigStorybook\Twig\TwigExtension(new \TwigStorybook\Service\StoryCollector(), '/../../../../' . $web_root));
 }
 
-$twig->addExtension(new TwigExtension($renderer, $urlGenerator, $themeManager, $dateFormatter, $fileUrlGenerator));
-
-$lintCommand = new LintCommand($twig);
-
-$app = new Application('twig-linter', (string) Versions::getVersion('sserbin/twig-linter'));
-$app->add($lintCommand);
-$app->setDefaultCommand('lint');
-$app->run();
+return $config;

--- a/scaffold/phpunit-testtraits.xml
+++ b/scaffold/phpunit-testtraits.xml
@@ -58,28 +58,46 @@
   </extensions>
   <testsuites>
     <testsuite name="unit">
-      <directory>../../../../web/modules/custom/**/tests/src/Unit</directory>
-      <directory>../../../../web/themes/custom/**/tests/src/Unit</directory>
-      <directory>../../../../web/profiles/custom/**/tests/src/Unit</directory>
+      <directory>../../../../web/modules/custom/*/tests/src/Unit</directory>
+      <directory>../../../../web/modules/custom/*/*/tests/src/Unit</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Unit</directory>
+      <directory>../../../../web/themes/custom/*/tests/src/Unit</directory>
+      <directory>../../../../web/themes/custom/*/*/tests/src/Unit</directory>
+      <directory>../../../../web/profiles/custom/*/tests/src/Unit</directory>
+      <directory>../../../../web/profiles/custom/*/*/tests/src/Unit</directory>
       <directory>../../../../test/phpunit/*/Unit</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>../../../../web/modules/custom/**/tests/src/Kernel</directory>
-      <directory>../../../../web/themes/custom/**/tests/src/Kernel</directory>
-      <directory>../../../../web/profiles/custom/**/tests/src/Kernel</directory>
+      <directory>../../../../web/modules/custom/*/tests/src/Kernel</directory>
+      <directory>../../../../web/modules/custom/*/*/tests/src/Kernel</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Kernel</directory>
       <directory>../../../../test/phpunit/*/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
-      <directory>../../../../web/modules/custom/**/tests/src/Functional</directory>
-      <directory>../../../../web/themes/custom/**/tests/src/Functional</directory>
-      <directory>../../../../web/profiles/custom/**/tests/src/Functional</directory>
+      <directory>../../../../web/modules/custom/*/tests/src/Functional</directory>
+      <directory>../../../../web/modules/custom/*/*/tests/src/Functional</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Functional</directory>
       <directory>../../../../test/phpunit/*/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
-      <directory>../../../../web/modules/custom/**/tests/src/FunctionalJavaScript</directory>
-      <directory>../../../../web/themes/custom/**/tests/src/FunctionalJavaScript</directory>
-      <directory>../../../../web/profiles/custom/**/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/modules/custom/*/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/modules/custom/*/*/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/FunctionalJavaScript</directory>
       <directory>../../../../test/phpunit/*/FunctionalJavaScript</directory>
+    </testsuite>
+    <testsuite name="existing-site">
+      <!-- Assumes tests are namespaced as \Drupal\Tests\custom_foo\ExistingSite. -->
+      <directory>../../../../web/modules/custom/*/tests/src/ExistingSite</directory>
+      <directory>../../../../test/phpunit/*/ExistingSite</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/ExistingSite</directory>
+      <directory>../../../../test/phpunit/*/ExistingSite</directory>
+    </testsuite>
+    <testsuite name="existing-site-javascript">
+      <!-- Assumes tests are namespaced as \Drupal\Tests\custom_foo\ExistingSiteJavascript. -->
+      <directory>../../../../web/modules/custom/*/tests/src/ExistingSiteJavascript</directory>
+      <directory>../../../../test/phpunit/*/ExistingSiteJavascript</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/ExistingSiteJavaScript</directory>
+      <directory>../../../../test/phpunit/*/ExistingSiteJavaScript</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/scaffold/phpunit-testtraits.xml
+++ b/scaffold/phpunit-testtraits.xml
@@ -31,44 +31,49 @@
     <env name="DTT_BASE_URL" value="http://web"/>
     <env name="DTT_MINK_DRIVER_ARGS" value='["chrome", {"browserName":"chrome","goog:chromeOptions":{"w3c": true, "args":["---no-sandbox","--ignore-certificate-errors", "--allow-insecure-localhost"]}}, "http://chrome:4444/wd/hub"]'/>
   </php>
+  <extensions>
+    <!-- Functional tests HTML output logging. -->
+    <bootstrap class="Drupal\TestTools\Extension\HtmlLogging\HtmlOutputLogger">
+      <!-- The directory where the browser output will be stored. If a relative
+        path is specified, it will be relative to the current working directory
+        of the process running the PHPUnit CLI. In CI environments, this can be
+        overridden by the value set for the "BROWSERTEST_OUTPUT_DIRECTORY"
+        environment variable.
+      -->
+      <parameter name="outputDirectory" value="test_result/phpunit"/>
+      <!-- By default browser tests print the individual links in the test run
+        report. To avoid overcrowding the output in CI environments, you can
+        set the "verbose" parameter or the "BROWSERTEST_OUTPUT_VERBOSE"
+        environment variable to "false". In GitLabCI, the output is saved
+        anyway as an artifact that can be browsed or downloaded from Gitlab.
+      -->
+      <parameter name="verbose" value="true"/>
+    </bootstrap>
+  </extensions>
   <testsuites>
     <testsuite name="unit">
-      <directory>../../../../web/modules/custom/*/tests/src/Unit</directory>
-      <directory>../../../../web/modules/custom/*/*/tests/src/Unit</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Unit</directory>
+      <directory>../../../../web/modules/custom/**/tests/src/Unit</directory>
+      <directory>../../../../web/themes/custom/**/tests/src/Unit</directory>
+      <directory>../../../../web/profiles/custom/**/tests/src/Unit</directory>
       <directory>../../../../test/phpunit/*/Unit</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>../../../../web/modules/custom/*/tests/src/Kernel</directory>
-      <directory>../../../../web/modules/custom/*/*/tests/src/Kernel</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Kernel</directory>
+      <directory>../../../../web/modules/custom/**/tests/src/Kernel</directory>
+      <directory>../../../../web/themes/custom/**/tests/src/Kernel</directory>
+      <directory>../../../../web/profiles/custom/**/tests/src/Kernel</directory>
       <directory>../../../../test/phpunit/*/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
-      <directory>../../../../web/modules/custom/*/tests/src/Functional</directory>
-      <directory>../../../../web/modules/custom/*/*/tests/src/Functional</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Functional</directory>
+      <directory>../../../../web/modules/custom/**/tests/src/Functional</directory>
+      <directory>../../../../web/themes/custom/**/tests/src/Functional</directory>
+      <directory>../../../../web/profiles/custom/**/tests/src/Functional</directory>
       <directory>../../../../test/phpunit/*/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
-      <directory>../../../../web/modules/custom/*/tests/src/FunctionalJavaScript</directory>
-      <directory>../../../../web/modules/custom/*/*/tests/src/FunctionalJavaScript</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/modules/custom/**/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/themes/custom/**/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/profiles/custom/**/tests/src/FunctionalJavaScript</directory>
       <directory>../../../../test/phpunit/*/FunctionalJavaScript</directory>
-    </testsuite>
-    <testsuite name="existing-site">
-      <!-- Assumes tests are namespaced as \Drupal\Tests\custom_foo\ExistingSite. -->
-      <directory>../../../../web/modules/custom/*/tests/src/ExistingSite</directory>
-      <directory>../../../../test/phpunit/*/ExistingSite</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/ExistingSite</directory>
-      <directory>../../../../test/phpunit/*/ExistingSite</directory>
-    </testsuite>
-    <testsuite name="existing-site-javascript">
-      <!-- Assumes tests are namespaced as \Drupal\Tests\custom_foo\ExistingSiteJavascript. -->
-      <directory>../../../../web/modules/custom/*/tests/src/ExistingSiteJavascript</directory>
-      <directory>../../../../test/phpunit/*/ExistingSiteJavascript</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/ExistingSiteJavaScript</directory>
-      <directory>../../../../test/phpunit/*/ExistingSiteJavaScript</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/scaffold/phpunit-testtraits.xml
+++ b/scaffold/phpunit-testtraits.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
          bootstrap="../../../weitzman/drupal-test-traits/src/bootstrap.php"
-         verbose="true"
->
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         failOnWarning="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         cacheResult="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache">
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>

--- a/scaffold/phpunit-testtraits.xml
+++ b/scaffold/phpunit-testtraits.xml
@@ -61,10 +61,6 @@
       <directory>../../../../web/modules/custom/*/tests/src/Unit</directory>
       <directory>../../../../web/modules/custom/*/*/tests/src/Unit</directory>
       <directory>../../../../web/modules/custom/*/modules/*/tests/src/Unit</directory>
-      <directory>../../../../web/themes/custom/*/tests/src/Unit</directory>
-      <directory>../../../../web/themes/custom/*/*/tests/src/Unit</directory>
-      <directory>../../../../web/profiles/custom/*/tests/src/Unit</directory>
-      <directory>../../../../web/profiles/custom/*/*/tests/src/Unit</directory>
       <directory>../../../../test/phpunit/*/Unit</directory>
     </testsuite>
     <testsuite name="kernel">

--- a/scaffold/phpunit.xml
+++ b/scaffold/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="../../../../web/core/tests/bootstrap.php"

--- a/scaffold/phpunit.xml
+++ b/scaffold/phpunit.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
          bootstrap="../../../../web/core/tests/bootstrap.php"
-         verbose="true"
->
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         failOnWarning="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         cacheResult="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache">
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
@@ -28,29 +34,48 @@
     <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
     <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","goog:chromeOptions":{"w3c": true, "args":["---no-sandbox","--ignore-certificate-errors", "--allow-insecure-localhost"]}}, "http://chrome:4444/wd/hub"]'/>
   </php>
+  <extensions>
+    <!-- Functional tests HTML output logging. -->
+    <bootstrap class="Drupal\TestTools\Extension\HtmlLogging\HtmlOutputLogger">
+      <!-- The directory where the browser output will be stored. If a relative
+        path is specified, it will be relative to the current working directory
+        of the process running the PHPUnit CLI. In CI environments, this can be
+        overridden by the value set for the "BROWSERTEST_OUTPUT_DIRECTORY"
+        environment variable.
+      -->
+      <parameter name="outputDirectory" value="test_result/phpunit"/>
+      <!-- By default browser tests print the individual links in the test run
+        report. To avoid overcrowding the output in CI environments, you can
+        set the "verbose" parameter or the "BROWSERTEST_OUTPUT_VERBOSE"
+        environment variable to "false". In GitLabCI, the output is saved
+        anyway as an artifact that can be browsed or downloaded from Gitlab.
+      -->
+      <parameter name="verbose" value="true"/>
+    </bootstrap>
+  </extensions>
   <testsuites>
     <testsuite name="unit">
-      <directory>../../../../web/modules/custom/*/tests/src/Unit</directory>
-      <directory>../../../../web/modules/custom/*/*/tests/src/Unit</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Unit</directory>
+      <directory>../../../../web/modules/custom/**/tests/src/Unit</directory>
+      <directory>../../../../web/themes/custom/**/tests/src/Unit</directory>
+      <directory>../../../../web/profiles/custom/**/tests/src/Unit</directory>
       <directory>../../../../test/phpunit/*/Unit</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>../../../../web/modules/custom/*/tests/src/Kernel</directory>
-      <directory>../../../../web/modules/custom/*/*/tests/src/Kernel</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Kernel</directory>
+      <directory>../../../../web/modules/custom/**/tests/src/Kernel</directory>
+      <directory>../../../../web/themes/custom/**/tests/src/Kernel</directory>
+      <directory>../../../../web/profiles/custom/**/tests/src/Kernel</directory>
       <directory>../../../../test/phpunit/*/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
-      <directory>../../../../web/modules/custom/*/tests/src/Functional</directory>
-      <directory>../../../../web/modules/custom/*/*/tests/src/Functional</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Functional</directory>
+      <directory>../../../../web/modules/custom/**/tests/src/Functional</directory>
+      <directory>../../../../web/themes/custom/**/tests/src/Functional</directory>
+      <directory>../../../../web/profiles/custom/**/tests/src/Functional</directory>
       <directory>../../../../test/phpunit/*/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
-      <directory>../../../../web/modules/custom/*/tests/src/FunctionalJavaScript</directory>
-      <directory>../../../../web/modules/custom/*/*/tests/src/FunctionalJavaScript</directory>
-      <directory>../../../../web/modules/custom/*/modules/*/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/modules/custom/**/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/themes/custom/**/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/profiles/custom/**/tests/src/FunctionalJavaScript</directory>
       <directory>../../../../test/phpunit/*/FunctionalJavaScript</directory>
     </testsuite>
   </testsuites>

--- a/scaffold/phpunit.xml
+++ b/scaffold/phpunit.xml
@@ -55,27 +55,28 @@
   </extensions>
   <testsuites>
     <testsuite name="unit">
-      <directory>../../../../web/modules/custom/**/tests/src/Unit</directory>
-      <directory>../../../../web/themes/custom/**/tests/src/Unit</directory>
-      <directory>../../../../web/profiles/custom/**/tests/src/Unit</directory>
+
+      <directory>../../../../web/modules/custom/*/tests/src/Unit</directory>
+      <directory>../../../../web/modules/custom/*/*/tests/src/Unit</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Unit</directory>
       <directory>../../../../test/phpunit/*/Unit</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>../../../../web/modules/custom/**/tests/src/Kernel</directory>
-      <directory>../../../../web/themes/custom/**/tests/src/Kernel</directory>
-      <directory>../../../../web/profiles/custom/**/tests/src/Kernel</directory>
+      <directory>../../../../web/modules/custom/*/tests/src/Kernel</directory>
+      <directory>../../../../web/modules/custom/*/*/tests/src/Kernel</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Kernel</directory>
       <directory>../../../../test/phpunit/*/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
-      <directory>../../../../web/modules/custom/**/tests/src/Functional</directory>
-      <directory>../../../../web/themes/custom/**/tests/src/Functional</directory>
-      <directory>../../../../web/profiles/custom/**/tests/src/Functional</directory>
+      <directory>../../../../web/modules/custom/*/tests/src/Functional</directory>
+      <directory>../../../../web/modules/custom/*/*/tests/src/Functional</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/Functional</directory>
       <directory>../../../../test/phpunit/*/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
-      <directory>../../../../web/modules/custom/**/tests/src/FunctionalJavaScript</directory>
-      <directory>../../../../web/themes/custom/**/tests/src/FunctionalJavaScript</directory>
-      <directory>../../../../web/profiles/custom/**/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/modules/custom/*/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/modules/custom/*/*/tests/src/FunctionalJavaScript</directory>
+      <directory>../../../../web/modules/custom/*/modules/*/tests/src/FunctionalJavaScript</directory>
       <directory>../../../../test/phpunit/*/FunctionalJavaScript</directory>
     </testsuite>
   </testsuites>

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -129,9 +129,9 @@ tasks:
         fi
         if [ "{{.format}}" == "junit" ]; then
           mkdir -p test_result
-          ./vendor/bin/phpunit --exclude-group=unit -c $CONFIG --log-junit $(pwd)/test_result/phpunit-functional.xml
+          ./vendor/bin/phpunit --exclude-testsuite=unit -c $CONFIG --log-junit $(pwd)/test_result/phpunit-functional.xml
         else
-          ./vendor/bin/phpunit -c $CONFIG --exclude-group=unit
+          ./vendor/bin/phpunit -c $CONFIG --exclude-testsuite=unit
         fi
   phpcs:
     desc: Runs PHPCS with Drupal Coding Standards

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -130,7 +130,7 @@ tasks:
           mkdir -p test_result/phpunit
           CONFIG="$CONFIG --log-junit $(pwd)/test_result/phpunit-functional.xml"
         fi
-        PHPUNIT_VERSION=$(/vendor/bin/phpunit --version | grep -Po 'PHPUnit ([0-9]+)\.') | grep -Po '[0-9]+')
+        PHPUNIT_VERSION=$(./vendor/bin/phpunit --version | grep -Po 'PHPUnit [0-9]+)\.' | grep -Po '[0-9]+')
         if [ "$PHPUNIT_VERSION" == "9" ]; then
           ./vendor/bin/phpunit -c $CONFIG --testsuite=kernel,functional,functional-javascript,existing-site,existing-site-javascript
         else

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -54,7 +54,11 @@ tasks:
       - |
         DIRS_ARR=({{.TWIG_DIRS}})
         for DIR in "${DIRS_ARR[@]}"; do
-          ./vendor/bin/drainpipe-twig-linter lint $DIR
+          if [ "{{.format}}" == "junit" ]; then
+            ./vendor/bin/twig-cs-fixer lint $DIR --format junit
+          else
+            ./vendor/bin/twig-cs-fixer lint $DIR
+          fi
         done
       - |
         if [ -f ".prettierrc.json" ] && [ -f "yarn.lock" ]; then
@@ -161,6 +165,11 @@ tasks:
         elif [ -f ".stylelintrc.json" ] && [ -f "package-lock.json" ]; then
           npm run stylelint "**/*.{css,scss,sass}" --fix
         fi
+      - |
+        DIRS_ARR=({{.TWIG_DIRS}})
+        for DIR in "${DIRS_ARR[@]}"; do
+          ./vendor/bin/twig-cs-fixer lint --fix $DIR
+        done
   nightwatch:check:
     #desc: Verifies Nightwatch is setup correctly
     cmds:

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -115,10 +115,9 @@ tasks:
         fi
         if [ "{{.format}}" == "junit" ]; then
           mkdir -p test_result/phpunit
-          ./vendor/bin/phpunit --testsuite=unit -c $CONFIG --log-junit $(pwd)/test_result/phpunit.xml
-        else
-          ./vendor/bin/phpunit -c $CONFIG --testsuite=unit
+          CONFIG="$CONFIG --log-junit $(pwd)/test_result/phpunit-functional.xml"
         fi
+        ./vendor/bin/phpunit -c $CONFIG --testsuite=unit
   phpunit:functional:
     desc: Runs PHPUnit functional tests
     cmds:
@@ -129,7 +128,11 @@ tasks:
         fi
         if [ "{{.format}}" == "junit" ]; then
           mkdir -p test_result/phpunit
-          ./vendor/bin/phpunit --exclude-testsuite=unit -c $CONFIG --log-junit $(pwd)/test_result/phpunit-functional.xml
+          CONFIG="$CONFIG --log-junit $(pwd)/test_result/phpunit-functional.xml"
+        fi
+        PHPUNIT_VERSION=$(/vendor/bin/phpunit --version | grep -Po 'PHPUnit ([0-9]+)\.') | grep -Po '[0-9]+')
+        if [ "$PHPUNIT_VERSION" == "9" ]; then
+          ./vendor/bin/phpunit -c $CONFIG --testsuite=kernel,functional,functional-javascript,existing-site,existing-site-javascript
         else
           ./vendor/bin/phpunit -c $CONFIG --exclude-testsuite=unit
         fi

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -114,7 +114,7 @@ tasks:
           CONFIG="$(pwd)/vendor/lullabot/drainpipe/scaffold/phpunit-testtraits.xml"
         fi
         if [ "{{.format}}" == "junit" ]; then
-          mkdir -p test_result
+          mkdir -p test_result/phpunit
           ./vendor/bin/phpunit --testsuite=unit -c $CONFIG --log-junit $(pwd)/test_result/phpunit.xml
         else
           ./vendor/bin/phpunit -c $CONFIG --testsuite=unit
@@ -128,7 +128,7 @@ tasks:
           CONFIG="$(pwd)/vendor/lullabot/drainpipe/scaffold/phpunit-testtraits.xml"
         fi
         if [ "{{.format}}" == "junit" ]; then
-          mkdir -p test_result
+          mkdir -p test_result/phpunit
           ./vendor/bin/phpunit --exclude-testsuite=unit -c $CONFIG --log-junit $(pwd)/test_result/phpunit-functional.xml
         else
           ./vendor/bin/phpunit -c $CONFIG --exclude-testsuite=unit

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -130,7 +130,7 @@ tasks:
           mkdir -p test_result/phpunit
           CONFIG="$CONFIG --log-junit $(pwd)/test_result/phpunit-functional.xml"
         fi
-        PHPUNIT_VERSION=$(./vendor/bin/phpunit --version | grep -Po 'PHPUnit [0-9]+)\.' | grep -Po '[0-9]+')
+        PHPUNIT_VERSION=$(./vendor/bin/phpunit --version | grep -Po 'PHPUnit [0-9]+\.' | grep -Po '[0-9]+')
         if [ "$PHPUNIT_VERSION" == "9" ]; then
           ./vendor/bin/phpunit -c $CONFIG --testsuite=kernel,functional,functional-javascript,existing-site,existing-site-javascript
         else

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -115,7 +115,7 @@ tasks:
         fi
         if [ "{{.format}}" == "junit" ]; then
           mkdir -p test_result/phpunit
-          CONFIG="$CONFIG --log-junit $(pwd)/test_result/phpunit-functional.xml"
+          CONFIG="$CONFIG --log-junit $(pwd)/test_result/phpunit.xml"
         fi
         ./vendor/bin/phpunit -c $CONFIG --testsuite=unit
   phpunit:functional:
@@ -124,7 +124,7 @@ tasks:
       - |
         CONFIG="$(pwd)/vendor/lullabot/drainpipe/scaffold/phpunit.xml"
         if [ "{{.DRUPAL_TEST_TRAITS}}" == "true" ]; then
-          CONFIG="$(pwd)/vendor/lullabot/drainpipe/scaffold/phpunit-testtraits.xml"
+          CONFIG="$(pwd)/vendor/lullabot/drainpipe/scaffold/phpunit-functional.xml"
         fi
         if [ "{{.format}}" == "junit" ]; then
           mkdir -p test_result/phpunit

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -124,7 +124,7 @@ tasks:
       - |
         CONFIG="$(pwd)/vendor/lullabot/drainpipe/scaffold/phpunit.xml"
         if [ "{{.DRUPAL_TEST_TRAITS}}" == "true" ]; then
-          CONFIG="$(pwd)/vendor/lullabot/drainpipe/scaffold/phpunit-functional.xml"
+          CONFIG="$(pwd)/vendor/lullabot/drainpipe/scaffold/phpunit-testtraits.xml"
         fi
         if [ "{{.format}}" == "junit" ]; then
           mkdir -p test_result/phpunit

--- a/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/Functional/UserCreateTest.php
+++ b/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/Functional/UserCreateTest.php
@@ -37,9 +37,10 @@ class UserCreateTest extends BrowserTestBase {
     public function testUserAdd() {
         $user = $this->drupalCreateUser(['administer users']);
         $this->drupalLogin($user);
+        $request_time = \Drupal::time()->getRequestTime();
 
-        $this->assertEquals(REQUEST_TIME, $user->getCreatedTime(), 'Creating a user sets default "created" timestamp.');
-        $this->assertEquals(REQUEST_TIME, $user->getChangedTime(), 'Creating a user sets default "changed" timestamp.');
+        $this->assertEquals($request_time, $user->getCreatedTime(), 'Creating a user sets default "created" timestamp.');
+        $this->assertEquals($request_time, $user->getChangedTime(), 'Creating a user sets default "changed" timestamp.');
 
         // Create a field.
         $field_name = 'test_field';

--- a/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/FunctionalJavascript/UserPasswordResetTest.php
+++ b/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/FunctionalJavascript/UserPasswordResetTest.php
@@ -65,7 +65,7 @@ class UserPasswordResetTest extends WebDriverTestBase {
 
         // Set the last login time that is used to generate the one-time link so
         // that it is definitely over a second ago.
-        $account->login = REQUEST_TIME - mt_rand(10, 100000);
+        $account->login = \Drupal::time()->getRequestTime() - mt_rand(10, 100000);
         Database::getConnection()->update('users_field_data')
             ->fields(['login' => $account->getLastLoginTime()])
             ->condition('uid', $account->id())

--- a/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/Unit/PermissionAccessCheckTest.php
+++ b/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/Unit/PermissionAccessCheckTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drupal\Tests\user\Unit;
+namespace Drupal\Tests\testsubmodule\Unit;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Tests\UnitTestCase;

--- a/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/Unit/PermissionAccessCheckTest.php
+++ b/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/Unit/PermissionAccessCheckTest.php
@@ -49,6 +49,7 @@ class PermissionAccessCheckTest extends UnitTestCase {
     /**
      * Provides data for the testAccess method.
      *
+     * @dataProvider providerTestAccess
      * @return array
      */
     public function providerTestAccess() {
@@ -64,9 +65,6 @@ class PermissionAccessCheckTest extends UnitTestCase {
 
     /**
      * Tests the access check method.
-     *
-     * @dataProvider providerTestAccess
-     * @covers ::access
      */
     public function testAccess($requirements, $access, array $contexts = [], $message = '') {
         $access_result = AccessResult::allowedIf($access)->addCacheContexts($contexts);

--- a/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/Unit/PermissionAccessCheckTest.php
+++ b/tests/fixtures/phpunit/testmodule/modules/testsubmodule/tests/src/Unit/PermissionAccessCheckTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Drupal\Tests\testsubmodule\Unit;
+declare(strict_types=1);
+
+namespace Drupal\Tests\user\Unit;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Tests\UnitTestCase;
@@ -16,72 +18,74 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class PermissionAccessCheckTest extends UnitTestCase {
 
-    /**
-     * The tested access checker.
-     *
-     * @var \Drupal\user\Access\PermissionAccessCheck
-     */
-    public $accessCheck;
+  /**
+   * The tested access checker.
+   *
+   * @var \Drupal\user\Access\PermissionAccessCheck
+   */
+  public $accessCheck;
 
-    /**
-     * The dependency injection container.
-     *
-     * @var \Symfony\Component\DependencyInjection\ContainerBuilder
-     */
-    protected $container;
+  /**
+   * The dependency injection container.
+   *
+   * @var \Symfony\Component\DependencyInjection\ContainerBuilder
+   */
+  protected $container;
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void {
-        parent::setUp();
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
 
-        $this->container = new ContainerBuilder();
-        $cache_contexts_manager = $this->prophesize(CacheContextsManager::class);
-        $cache_contexts_manager->assertValidTokens()->willReturn(TRUE);
-        $cache_contexts_manager->reveal();
-        $this->container->set('cache_contexts_manager', $cache_contexts_manager);
-        \Drupal::setContainer($this->container);
+    $this->container = new ContainerBuilder();
+    $cache_contexts_manager = $this->prophesize(CacheContextsManager::class);
+    $cache_contexts_manager->assertValidTokens()->willReturn(TRUE);
+    $cache_contexts_manager->reveal();
+    $this->container->set('cache_contexts_manager', $cache_contexts_manager);
+    \Drupal::setContainer($this->container);
 
-        $this->accessCheck = new PermissionAccessCheck();
+    $this->accessCheck = new PermissionAccessCheck();
+  }
+
+  /**
+   * Provides data for the testAccess method.
+   *
+   * @return array
+   */
+  public static function providerTestAccess() {
+    return [
+      [[], FALSE],
+      [['_permission' => 'allowed'], TRUE, ['user.permissions']],
+      [['_permission' => 'denied'], FALSE, ['user.permissions'], "The 'denied' permission is required."],
+      [['_permission' => 'allowed+denied'], TRUE, ['user.permissions']],
+      [['_permission' => 'allowed+denied+other'], TRUE, ['user.permissions']],
+      [['_permission' => 'allowed,denied'], FALSE, ['user.permissions'], "The following permissions are required: 'allowed' AND 'denied'."],
+    ];
+  }
+
+  /**
+   * Tests the access check method.
+   *
+   * @dataProvider providerTestAccess
+   * @covers ::access
+   */
+  public function testAccess($requirements, $access, array $contexts = [], $message = ''): void {
+    $access_result = AccessResult::allowedIf($access)->addCacheContexts($contexts);
+    if (!empty($message)) {
+      $access_result->setReason($message);
     }
+    $user = $this->createMock('Drupal\Core\Session\AccountInterface');
+    $user->expects($this->any())
+      ->method('hasPermission')
+      ->willReturnMap([
+        ['allowed', TRUE],
+        ['denied', FALSE],
+        ['other', FALSE],
+      ]);
+    $route = new Route('', [], $requirements);
 
-    /**
-     * Provides data for the testAccess method.
-     *
-     * @dataProvider providerTestAccess
-     * @return array
-     */
-    public function providerTestAccess() {
-        return [
-            [[], FALSE],
-            [['_permission' => 'allowed'], TRUE, ['user.permissions']],
-            [['_permission' => 'denied'], FALSE, ['user.permissions'], "The 'denied' permission is required."],
-            [['_permission' => 'allowed+denied'], TRUE, ['user.permissions']],
-            [['_permission' => 'allowed+denied+other'], TRUE, ['user.permissions']],
-            [['_permission' => 'allowed,denied'], FALSE, ['user.permissions'], "The following permissions are required: 'allowed' AND 'denied'."],
-        ];
-    }
-
-    /**
-     * Tests the access check method.
-     */
-    public function testAccess($requirements, $access, array $contexts = [], $message = '') {
-        $access_result = AccessResult::allowedIf($access)->addCacheContexts($contexts);
-        if (!empty($message)) {
-            $access_result->setReason($message);
-        }
-        $user = $this->createMock('Drupal\Core\Session\AccountInterface');
-        $user->expects($this->any())
-            ->method('hasPermission')
-            ->willReturnMap([
-                ['allowed', TRUE],
-                ['denied', FALSE],
-                ['other', FALSE],
-            ]);
-        $route = new Route('', [], $requirements);
-
-        $this->assertEquals($access_result, $this->accessCheck->access($route, $user));
-    }
+    $this->assertEquals($access_result, $this->accessCheck->access($route, $user));
+  }
 
 }

--- a/tests/fixtures/phpunit/testmodule/tests/src/Functional/UserCreateTest.php
+++ b/tests/fixtures/phpunit/testmodule/tests/src/Functional/UserCreateTest.php
@@ -37,9 +37,10 @@ class UserCreateTest extends BrowserTestBase {
     public function testUserAdd() {
         $user = $this->drupalCreateUser(['administer users']);
         $this->drupalLogin($user);
+        $request_time = \Drupal::time()->getRequestTime();
 
-        $this->assertEquals(REQUEST_TIME, $user->getCreatedTime(), 'Creating a user sets default "created" timestamp.');
-        $this->assertEquals(REQUEST_TIME, $user->getChangedTime(), 'Creating a user sets default "changed" timestamp.');
+        $this->assertEquals($request_time, $user->getCreatedTime(), 'Creating a user sets default "created" timestamp.');
+        $this->assertEquals($request_time, $user->getChangedTime(), 'Creating a user sets default "changed" timestamp.');
 
         // Create a field.
         $field_name = 'test_field';

--- a/tests/fixtures/phpunit/testmodule/tests/src/FunctionalJavascript/UserPasswordResetTest.php
+++ b/tests/fixtures/phpunit/testmodule/tests/src/FunctionalJavascript/UserPasswordResetTest.php
@@ -65,7 +65,7 @@ class UserPasswordResetTest extends WebDriverTestBase {
 
         // Set the last login time that is used to generate the one-time link so
         // that it is definitely over a second ago.
-        $account->login = REQUEST_TIME - mt_rand(10, 100000);
+        $account->login = \Drupal::time()->getRequestTime() - mt_rand(10, 100000);
         Database::getConnection()->update('users_field_data')
             ->fields(['login' => $account->getLastLoginTime()])
             ->condition('uid', $account->id())

--- a/tests/fixtures/phpunit/testmodule/tests/src/Unit/PermissionAccessCheckTest.php
+++ b/tests/fixtures/phpunit/testmodule/tests/src/Unit/PermissionAccessCheckTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Drupal\Tests\user\Unit;
+namespace Drupal\Tests\testmodule\Unit;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Tests\UnitTestCase;

--- a/tests/fixtures/phpunit/testmodule/tests/src/Unit/PermissionAccessCheckTest.php
+++ b/tests/fixtures/phpunit/testmodule/tests/src/Unit/PermissionAccessCheckTest.php
@@ -49,6 +49,7 @@ class PermissionAccessCheckTest extends UnitTestCase {
     /**
      * Provides data for the testAccess method.
      *
+     * @dataProvider providerTestAccess
      * @return array
      */
     public function providerTestAccess() {
@@ -64,9 +65,6 @@ class PermissionAccessCheckTest extends UnitTestCase {
 
     /**
      * Tests the access check method.
-     *
-     * @dataProvider providerTestAccess
-     * @covers ::access
      */
     public function testAccess($requirements, $access, array $contexts = [], $message = '') {
         $access_result = AccessResult::allowedIf($access)->addCacheContexts($contexts);

--- a/tests/fixtures/phpunit/testmodule/tests/src/Unit/PermissionAccessCheckTest.php
+++ b/tests/fixtures/phpunit/testmodule/tests/src/Unit/PermissionAccessCheckTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Drupal\Tests\testmodule\Unit;
+declare(strict_types=1);
+
+namespace Drupal\Tests\user\Unit;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Tests\UnitTestCase;
@@ -16,72 +18,74 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class PermissionAccessCheckTest extends UnitTestCase {
 
-    /**
-     * The tested access checker.
-     *
-     * @var \Drupal\user\Access\PermissionAccessCheck
-     */
-    public $accessCheck;
+  /**
+   * The tested access checker.
+   *
+   * @var \Drupal\user\Access\PermissionAccessCheck
+   */
+  public $accessCheck;
 
-    /**
-     * The dependency injection container.
-     *
-     * @var \Symfony\Component\DependencyInjection\ContainerBuilder
-     */
-    protected $container;
+  /**
+   * The dependency injection container.
+   *
+   * @var \Symfony\Component\DependencyInjection\ContainerBuilder
+   */
+  protected $container;
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void {
-        parent::setUp();
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
 
-        $this->container = new ContainerBuilder();
-        $cache_contexts_manager = $this->prophesize(CacheContextsManager::class);
-        $cache_contexts_manager->assertValidTokens()->willReturn(TRUE);
-        $cache_contexts_manager->reveal();
-        $this->container->set('cache_contexts_manager', $cache_contexts_manager);
-        \Drupal::setContainer($this->container);
+    $this->container = new ContainerBuilder();
+    $cache_contexts_manager = $this->prophesize(CacheContextsManager::class);
+    $cache_contexts_manager->assertValidTokens()->willReturn(TRUE);
+    $cache_contexts_manager->reveal();
+    $this->container->set('cache_contexts_manager', $cache_contexts_manager);
+    \Drupal::setContainer($this->container);
 
-        $this->accessCheck = new PermissionAccessCheck();
+    $this->accessCheck = new PermissionAccessCheck();
+  }
+
+  /**
+   * Provides data for the testAccess method.
+   *
+   * @return array
+   */
+  public static function providerTestAccess() {
+    return [
+      [[], FALSE],
+      [['_permission' => 'allowed'], TRUE, ['user.permissions']],
+      [['_permission' => 'denied'], FALSE, ['user.permissions'], "The 'denied' permission is required."],
+      [['_permission' => 'allowed+denied'], TRUE, ['user.permissions']],
+      [['_permission' => 'allowed+denied+other'], TRUE, ['user.permissions']],
+      [['_permission' => 'allowed,denied'], FALSE, ['user.permissions'], "The following permissions are required: 'allowed' AND 'denied'."],
+    ];
+  }
+
+  /**
+   * Tests the access check method.
+   *
+   * @dataProvider providerTestAccess
+   * @covers ::access
+   */
+  public function testAccess($requirements, $access, array $contexts = [], $message = ''): void {
+    $access_result = AccessResult::allowedIf($access)->addCacheContexts($contexts);
+    if (!empty($message)) {
+      $access_result->setReason($message);
     }
+    $user = $this->createMock('Drupal\Core\Session\AccountInterface');
+    $user->expects($this->any())
+      ->method('hasPermission')
+      ->willReturnMap([
+        ['allowed', TRUE],
+        ['denied', FALSE],
+        ['other', FALSE],
+      ]);
+    $route = new Route('', [], $requirements);
 
-    /**
-     * Provides data for the testAccess method.
-     *
-     * @dataProvider providerTestAccess
-     * @return array
-     */
-    public function providerTestAccess() {
-        return [
-            [[], FALSE],
-            [['_permission' => 'allowed'], TRUE, ['user.permissions']],
-            [['_permission' => 'denied'], FALSE, ['user.permissions'], "The 'denied' permission is required."],
-            [['_permission' => 'allowed+denied'], TRUE, ['user.permissions']],
-            [['_permission' => 'allowed+denied+other'], TRUE, ['user.permissions']],
-            [['_permission' => 'allowed,denied'], FALSE, ['user.permissions'], "The following permissions are required: 'allowed' AND 'denied'."],
-        ];
-    }
-
-    /**
-     * Tests the access check method.
-     */
-    public function testAccess($requirements, $access, array $contexts = [], $message = '') {
-        $access_result = AccessResult::allowedIf($access)->addCacheContexts($contexts);
-        if (!empty($message)) {
-            $access_result->setReason($message);
-        }
-        $user = $this->createMock('Drupal\Core\Session\AccountInterface');
-        $user->expects($this->any())
-            ->method('hasPermission')
-            ->willReturnMap([
-                ['allowed', TRUE],
-                ['denied', FALSE],
-                ['other', FALSE],
-            ]);
-        $route = new Route('', [], $requirements);
-
-        $this->assertEquals($access_result, $this->accessCheck->access($route, $user));
-    }
+    $this->assertEquals($access_result, $this->accessCheck->access($route, $user));
+  }
 
 }

--- a/tests/local-test.sh
+++ b/tests/local-test.sh
@@ -2,7 +2,7 @@
 set -eux
 # Helper script to setup a local test of Drainpipe
 # Copy this to the same directory level that your drainpipe directory is in
-composer create-project drupal/recommended-project drainpipe-test --ignore-platform-req=ext-gd
+composer create-project drupal/recommended-project drainpipe-test --ignore-platform-reqs
 cd drainpipe-test
 cp -R ../drainpipe .
 


### PR DESCRIPTION
- Replace sserbin/twig-linter with vincentlanglet/twig-cs-fixer/ - sserbin/twig-linter depends on an old version of symfony/console and core is adopting this new package at some point https://www.drupal.org/project/drupal/issues/3284817 - it also has a much better extension mechanism which will help if something like #615 comes up again
- Update Pantheon settings for Drupal 11
- Update PHPUnit configurations and tests for Drupal 11
- Fix mysterious yarn issues with DDEV