### PR TITLE
Output php configurations without escaping them #625

### DIFF
--- a/.github/workflows/TestTugboat.yml
+++ b/.github/workflows/TestTugboat.yml
@@ -53,6 +53,7 @@ jobs:
           echo "    - foo" >> .tugboat/config.drainpipe-override.yml
           echo "  urls:" >> .tugboat/config.drainpipe-override.yml
           echo "    - /" >> .tugboat/config.drainpipe-override.yml
+          echo "    - /v?=1" >> .tugboat/config.drainpipe-override.yml
           echo "  screenshot:" >> .tugboat/config.drainpipe-override.yml
           echo "    timeout: 45" >> .tugboat/config.drainpipe-override.yml
           echo "  visualdiff:" >> .tugboat/config.drainpipe-override.yml

--- a/.github/workflows/TestTugboat.yml
+++ b/.github/workflows/TestTugboat.yml
@@ -53,7 +53,7 @@ jobs:
           echo "    - foo" >> .tugboat/config.drainpipe-override.yml
           echo "  urls:" >> .tugboat/config.drainpipe-override.yml
           echo "    - /" >> .tugboat/config.drainpipe-override.yml
-          echo "    - /v?=1" >> .tugboat/config.drainpipe-override.yml
+          echo "    - /?v=1" >> .tugboat/config.drainpipe-override.yml
           echo "  screenshot:" >> .tugboat/config.drainpipe-override.yml
           echo "    timeout: 45" >> .tugboat/config.drainpipe-override.yml
           echo "  visualdiff:" >> .tugboat/config.drainpipe-override.yml

--- a/.tugboat/config.drainpipe-override.yml
+++ b/.tugboat/config.drainpipe-override.yml
@@ -3,6 +3,7 @@ php:
     - foo
   urls:
     - /
+    - /?v=1
   screenshot:
     timeout: 45
   visualdiff:

--- a/.tugboat/config.drainpipe-override.yml
+++ b/.tugboat/config.drainpipe-override.yml
@@ -3,7 +3,6 @@ php:
     - foo
   urls:
     - /
-    - /?v=1
   screenshot:
     timeout: 45
   visualdiff:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -28,7 +28,7 @@ services:
       - foo
     urls:
       - /
-      - /?v=1
+      - '/?v=1'
     screenshot:
       timeout: 45
     visualdiff:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -28,6 +28,7 @@ services:
       - foo
     urls:
       - /
+      - /?v=1
     screenshot:
       timeout: 45
     visualdiff:

--- a/scaffold/tugboat/config.yml.twig
+++ b/scaffold/tugboat/config.yml.twig
@@ -29,7 +29,7 @@ services:
 {% endif %}
 {% if overrides.php|length > 0 %}
 
-{{ overrides.php }}
+{{ overrides.php|raw }}
 {% endif %}
 
   {{ database_type }}:


### PR DESCRIPTION
Fixes URLs with parameters for visual diffs in  .tugboat/config.drainpipe-override.yml