### PR TITLE
ISSUE-398: fail if there are red lines in the Status Report admin page

### DIFF
--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -42,6 +42,11 @@ tasks:
     cmds:
       # @see https://architecture.lullabot.com/adr/20211026-one-time-login-first-drupal-user-account/
       - ./vendor/bin/drush user:unblock --uid=1
+      - |
+          [ $(drush core:requirements --severity=2 --format=tsv | wc -l) -lt 1 ] \
+          && echo "🟢 Status Report page checked" \
+          || false || echo "🔴 Status Report page check failed"
+
       # Ignore the below modules in sites/default/settings.php e.g.
       # $settings['config_exclude_modules'] = ['stage_file_proxy', 'field_ui', 'views_ui'];
       # - ./vendor/bin/drush pm:enable stage_file_proxy views_ui field_ui -y

--- a/scaffold/Taskfile.yml
+++ b/scaffold/Taskfile.yml
@@ -45,7 +45,7 @@ tasks:
       - |
           [ $(drush core:requirements --severity=2 --format=tsv | wc -l) -lt 1 ] \
           && echo "🟢 Status Report page checked" \
-          || false || echo "🔴 Status Report page check failed"
+          || echo "🔴 Status Report page check failed"
 
       # Ignore the below modules in sites/default/settings.php e.g.
       # $settings['config_exclude_modules'] = ['stage_file_proxy', 'field_ui', 'views_ui'];

--- a/tests/fixtures/drainpipe-task-upgrade/Taskfile.yml
+++ b/tests/fixtures/drainpipe-task-upgrade/Taskfile.yml
@@ -42,6 +42,11 @@ tasks:
     cmds:
       # @see https://architecture.lullabot.com/adr/20211026-one-time-login-first-drupal-user-account/
       - ./vendor/bin/drush user:unblock --uid=1
+      - |
+          [ $(drush core:requirements --severity=2 --format=tsv | wc -l) -lt 1 ] \
+          && echo "🟢 Status Report page checked" \
+          || false || echo "🔴 Status Report page check failed"
+
       # Ignore the below modules in sites/default/settings.php e.g.
       # $settings['config_exclude_modules'] = ['stage_file_proxy', 'field_ui', 'views_ui'];
       # - ./vendor/bin/drush pm:enable stage_file_proxy views_ui field_ui -y

--- a/tests/fixtures/drainpipe-task-upgrade/Taskfile.yml
+++ b/tests/fixtures/drainpipe-task-upgrade/Taskfile.yml
@@ -45,7 +45,7 @@ tasks:
       - |
           [ $(drush core:requirements --severity=2 --format=tsv | wc -l) -lt 1 ] \
           && echo "🟢 Status Report page checked" \
-          || false || echo "🔴 Status Report page check failed"
+          || echo "🔴 Status Report page check failed"
 
       # Ignore the below modules in sites/default/settings.php e.g.
       # $settings['config_exclude_modules'] = ['stage_file_proxy', 'field_ui', 'views_ui'];


### PR DESCRIPTION
Adds a check that fails if there are errors in the Status Report page.