### PR TITLE
Fix creating archives in the temporary directory and not the cwd

### DIFF
--- a/tasks/snapshot.yml
+++ b/tasks/snapshot.yml
@@ -57,6 +57,7 @@ tasks:
         TMP_DIR=$(mktemp -d)
         cp -Rp . $TMP_DIR
         if [ ! -f ".drainpipeignore" ]; then echo ".drainpipeignore does not exist" && touch $TMP_DIR/.drainpipeignore; fi
+        DESTINATION=$(realpath {{ .o }})
         cd $TMP_DIR
         {{ .PREPARE_DIRECTORY }}
         git config user.email 'no-reply@lullabot.com'
@@ -64,5 +65,5 @@ tasks:
         git commit --quiet --message "Initial commit" --no-gpg-sign
         git config tar.tar.xz.command "xz -c"
         git config tar.tar.bz2.command "bzip2 -c"
-        git archive -o {{.o}} HEAD
-        test -f {{.o}}
+        git -C $TMP_DIR archive -o "$DESTINATION" HEAD
+        test -f "$DESTINATION"


### PR DESCRIPTION
If you run a command like `task snapshot:archive o=archive.tar.xz`, the archive gets created in `/tmp/<something>`. As a caller, you don't know what `<something>` is so you can't get the archive. This can be worked around if you use an absolute path for `o=`, but this PR should fix it so relative paths work too.