### PR TITLE
chore(release): publish

### DIFF
--- a/metapackages/javascript/CHANGELOG.md
+++ b/metapackages/javascript/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.6](https://github.com/lullabot/drainpipe/compare/@lullabot/drainpipe-javascript@0.0.4...@lullabot/drainpipe-javascript@0.0.6) (2024-09-30)
+
+
+### Bug Fixes
+
+* **deps:** update dependency esbuild to ^0.21.1 ([#565](https://github.com/lullabot/drainpipe/issues/565)) ([85634d7](https://github.com/lullabot/drainpipe/commit/85634d73dc4dfb27fbd33b14222083b28306c0a9))
+* **deps:** update dependency esbuild to ^0.21.2 ([#571](https://github.com/lullabot/drainpipe/issues/571)) ([538ef91](https://github.com/lullabot/drainpipe/commit/538ef910939b4aaab2136d8ab9473b99b6188e87))
+* **deps:** update dependency esbuild to ^0.21.3 ([#574](https://github.com/lullabot/drainpipe/issues/574)) ([251a1fb](https://github.com/lullabot/drainpipe/commit/251a1fb198ca4e4700b9edde100cf76d4913f1c2))
+* **deps:** update dependency esbuild to ^0.21.4 ([#580](https://github.com/lullabot/drainpipe/issues/580)) ([3c8d65f](https://github.com/lullabot/drainpipe/commit/3c8d65f3703b0aa660680eae8d647b0f4e662fd1))
+* **deps:** update dependency esbuild to ^0.21.5 ([#589](https://github.com/lullabot/drainpipe/issues/589)) ([731567f](https://github.com/lullabot/drainpipe/commit/731567faffecd798f0ac0fbf6b170d49ed2aef44))
+* **deps:** update dependency esbuild to ^0.23.0 ([#599](https://github.com/lullabot/drainpipe/issues/599)) ([c3ec211](https://github.com/lullabot/drainpipe/commit/c3ec2118cda9bfadf614e6445292029af2400f49))
+* **deps:** update dependency esbuild to ^0.23.1 ([#660](https://github.com/lullabot/drainpipe/issues/660)) ([c2861ed](https://github.com/lullabot/drainpipe/commit/c2861ed54e365675a66317a4253f44c0ac501b7b))
+* **deps:** update dependency esbuild to ^0.24.0 ([#701](https://github.com/lullabot/drainpipe/issues/701)) ([06ed886](https://github.com/lullabot/drainpipe/commit/06ed886fdd946efaf958db15b902b69dfa560640))
+
+
+
+
+
 ## [0.0.5](https://github.com/lullabot/drainpipe/compare/@lullabot/drainpipe-javascript@0.0.4...@lullabot/drainpipe-javascript@0.0.5) (2024-09-30)
 
 

--- a/metapackages/javascript/package.json
+++ b/metapackages/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lullabot/drainpipe-javascript",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "bin": "./esbuild.js",
   "dependencies": {
     "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.15",

--- a/metapackages/sass/CHANGELOG.md
+++ b/metapackages/sass/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.4](https://github.com/lullabot/drainpipe/compare/@lullabot/drainpipe-sass@0.1.2...@lullabot/drainpipe-sass@0.1.4) (2024-09-30)
+
+
+### Bug Fixes
+
+* **deps:** update dependency autoprefixer to ^10.4.20 ([#632](https://github.com/lullabot/drainpipe/issues/632)) ([068fefb](https://github.com/lullabot/drainpipe/commit/068fefb146d5a252f050d50516cf54391db6f24c))
+* **deps:** update dependency cssnano to ^7.0.5 ([#641](https://github.com/lullabot/drainpipe/issues/641)) ([ab78512](https://github.com/lullabot/drainpipe/commit/ab78512a35e6cd8178fff858327966e4cdf0be9c))
+* **deps:** update dependency cssnano to ^7.0.6 ([#682](https://github.com/lullabot/drainpipe/issues/682)) ([3f1c8d1](https://github.com/lullabot/drainpipe/commit/3f1c8d1bece72ab6163b7a70e2920d8476ee1f9b))
+* **deps:** update dependency modern-normalize to ^3.0.1 ([#683](https://github.com/lullabot/drainpipe/issues/683)) ([648b386](https://github.com/lullabot/drainpipe/commit/648b38651d7619f3ad8f7981cce599edec5bb40c))
+* **deps:** update dependency modern-normalize to v3 ([#648](https://github.com/lullabot/drainpipe/issues/648)) ([705ad75](https://github.com/lullabot/drainpipe/commit/705ad753e390647d37177a4a071adac6da799d38))
+* **deps:** update dependency postcss to ^8.4.40 ([#623](https://github.com/lullabot/drainpipe/issues/623)) ([ad02cda](https://github.com/lullabot/drainpipe/commit/ad02cda93b02989f41ddf89c4414dff498803c7e))
+* **deps:** update dependency postcss to ^8.4.47 ([#707](https://github.com/lullabot/drainpipe/issues/707)) ([638a865](https://github.com/lullabot/drainpipe/commit/638a86562f6672be3f6c77db218d6cee058701b5))
+* **deps:** update dependency sass to ^1.78.0 ([#678](https://github.com/lullabot/drainpipe/issues/678)) ([c0a1a08](https://github.com/lullabot/drainpipe/commit/c0a1a08d863892f96618973370ca5e0592ed7128))
+* **deps:** update dependency sass to ^1.79.1 ([#696](https://github.com/lullabot/drainpipe/issues/696)) ([10f5b41](https://github.com/lullabot/drainpipe/commit/10f5b415b9641af0ce293e83f794cea6237c1498))
+* **deps:** update dependency sass to ^1.79.2 ([#698](https://github.com/lullabot/drainpipe/issues/698)) ([86e68a7](https://github.com/lullabot/drainpipe/commit/86e68a7244181844ab5a54592deca452992da1fd))
+* **deps:** update dependency sass to ^1.79.3 ([#700](https://github.com/lullabot/drainpipe/issues/700)) ([09271f0](https://github.com/lullabot/drainpipe/commit/09271f0cf0a1b1d3f349f20c6083c9c43e55b9a4))
+* **deps:** update dependency sass to ^1.79.4 ([#710](https://github.com/lullabot/drainpipe/issues/710)) ([bbf55fb](https://github.com/lullabot/drainpipe/commit/bbf55fb4db0b617d96317c76b70b55853910624e))
+
+
+
+## 3.8.1 (2024-07-16)
+
+
+### Bug Fixes
+
+* **deps:** update dependency cssnano to ^7.0.2 ([#587](https://github.com/lullabot/drainpipe/issues/587)) ([2316131](https://github.com/lullabot/drainpipe/commit/2316131f560d8402303b13486f067692906318c4))
+* **deps:** update dependency cssnano to ^7.0.3 ([#594](https://github.com/lullabot/drainpipe/issues/594)) ([bbe42fd](https://github.com/lullabot/drainpipe/commit/bbe42fd202b5af0713b4558df4deffc0a1c91157))
+* **deps:** update dependency cssnano to ^7.0.4 ([#600](https://github.com/lullabot/drainpipe/issues/600)) ([35853d1](https://github.com/lullabot/drainpipe/commit/35853d11b4a6b52f676e1540917e3d46c12fbbfe))
+* **deps:** update dependency cssnano to v7 ([#547](https://github.com/lullabot/drainpipe/issues/547)) ([a62773b](https://github.com/lullabot/drainpipe/commit/a62773bb41846751a06126e663d068e259c92de0))
+* **deps:** update dependency postcss to ^8.4.39 ([#598](https://github.com/lullabot/drainpipe/issues/598)) ([bf74bf8](https://github.com/lullabot/drainpipe/commit/bf74bf805183d098288ef63df2214d6483c5f700))
+* **deps:** update dependency sass to ^1.76.0 ([#554](https://github.com/lullabot/drainpipe/issues/554)) ([7bb8549](https://github.com/lullabot/drainpipe/commit/7bb85492dfbeba22718c362dda9c68fef7b93b2b))
+* **deps:** update dependency sass to ^1.77.1 ([#566](https://github.com/lullabot/drainpipe/issues/566)) ([8acb0f2](https://github.com/lullabot/drainpipe/commit/8acb0f2c400ef1fdd2a0ef085643b76dcf353e52))
+* **deps:** update dependency sass to ^1.77.2 ([#577](https://github.com/lullabot/drainpipe/issues/577)) ([e1c1f22](https://github.com/lullabot/drainpipe/commit/e1c1f22a2e577906a2adc690b42a8062ae748b86))
+* **deps:** update dependency sass to ^1.77.3 ([#584](https://github.com/lullabot/drainpipe/issues/584)) ([d4fe8eb](https://github.com/lullabot/drainpipe/commit/d4fe8eb597e94fc453783e1a38074df355413a9b))
+* **deps:** update dependency sass to ^1.77.4 ([#585](https://github.com/lullabot/drainpipe/issues/585)) ([e901ea7](https://github.com/lullabot/drainpipe/commit/e901ea798d55602c8b662077a2623a84018e4fa3))
+* **deps:** update dependency sass to ^1.77.5 ([#592](https://github.com/lullabot/drainpipe/issues/592)) ([6db0251](https://github.com/lullabot/drainpipe/commit/6db025155d138a8a97d20b71ca7c290c23163dd8))
+* **deps:** update dependency sass to ^1.77.6 ([#593](https://github.com/lullabot/drainpipe/issues/593)) ([2d4767f](https://github.com/lullabot/drainpipe/commit/2d4767f9ab3c41f5dd0755485f434aec4e829011))
+* **deps:** update dependency sass to ^1.77.8 ([#604](https://github.com/lullabot/drainpipe/issues/604)) ([e2b419d](https://github.com/lullabot/drainpipe/commit/e2b419d7e671ca9a67fb55101c081d1cfda24c82))
+
+
+
+
+
 ## [0.1.3](https://github.com/lullabot/drainpipe/compare/@lullabot/drainpipe-sass@0.1.2...@lullabot/drainpipe-sass@0.1.3) (2024-09-30)
 
 

--- a/metapackages/sass/package.json
+++ b/metapackages/sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lullabot/drainpipe-sass",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "bin": "./gulp.js",
   "dependencies": {
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
 - @lullabot/drainpipe-javascript@0.0.6
 - @lullabot/drainpipe-sass@0.1.4