### PR TITLE
fix(#743): "drupal:db-import" frozen if $DB_DIR/db.sql.gz already exists

### DIFF
--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -44,7 +44,7 @@ tasks:
       - echo "🚮 Dropping existing database"
       - ./vendor/bin/drush {{ .site }} sql:drop --yes
       - echo "📰 Importing database"
-      - gunzip -k $DB_DIR/db.sql.gz
+      - gunzip --keep --force $DB_DIR/db.sql.gz
       - ./vendor/bin/drush {{ .site }} sql:query --file=$DB_DIR/db.sql
       - defer: rm -f $DB_DIR/db.sql
   export-db:


### PR DESCRIPTION
Fixes #743.