### PR TITLE
Issue #677: Avoid composer lock diff action if composer.lock has not changed.

### DIFF
--- a/scaffold/github/workflows/ComposerLockDiff.yml
+++ b/scaffold/github/workflows/ComposerLockDiff.yml
@@ -3,6 +3,8 @@ name: "Composer Lock Diff"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'composer.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
### Relates to:
- #677 

### Description:
- Avoid composer lock diff action if composer.lock has not changed.