### PR TITLE
Issue #797: improving renovate config to support ranges and ignoring drainpipe releases.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,21 @@
       "addLabels": [
         "test only - do not merge"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "lullabot/drainpipe",
+        "lullabot/drainpipe-dev"
+      ],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["drush/drush"],
+      "allowedVersions": "^11 || ^12 || ^13"
+    },
+    {
+      "matchPackagePatterns": ["^symfony/"],
+      "allowedVersions": "^6 || ^7"
     }
   ]
 }


### PR DESCRIPTION
Resolves: #797 

This pull request includes updates to the `renovate.json` file to manage package dependencies more effectively. The most important changes involve adding specific rules for certain packages and setting version constraints.

Dependency management updates:

* Added a rule to disable updates for `lullabot/drainpipe` and `lullabot/drainpipe-dev` packages.
* Added a rule to allow versions `^11`, `^12`, and `^13` for the `drush/drush` package.
* Added a rule to allow versions `^6` and `^7` for packages matching the pattern `^symfony/`.