### PR TITLE
Issue #769: Use gitattributes to remove drainpipe-dev

### DIFF
--- a/.drainpipeignore
+++ b/.drainpipeignore
@@ -1,2 +1,1 @@
 web/sites/default/files
-/drainpipe-dev/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 .yarn/* -diff
 .pnp.js -diff
 .pnp.cjs -diff
+/drainpipe-dev export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ tests/fixtures/drainpipe-test-project/*
 .npmrc
 lerna-debug.log
 node_modules
-/drainpipe-dev/
+
 ################
 # Editors / OS #
 ################


### PR DESCRIPTION
Reverts Lullabot/drainpipe#840

Fixes #769 for real using .gitattributes to ignore the `drainpipe-dev` folder instead of .gitignore, which I realized afterwards will prevent you from making changes on a local checkout that can be committed.

See https://git-scm.com/docs/gitattributes#_export_ignore