### PR TITLE
Add skip_permissions_hardening setting flag to ensure Tugboat builds keep the sites/default directory writable

### DIFF
--- a/.tugboat/steps/2-update.sh
+++ b/.tugboat/steps/2-update.sh
@@ -12,6 +12,9 @@ mv .tugboat .tugboat-tmp
 composer install
 ./vendor/bin/task sync
 
+# Ensure the sites directories are writable.
+chmod 755 ${DOCROOT}/sites/*/
+
 # Set file permissions such that Drupal will not complain.
 chgrp -R www-data "${DOCROOT}/sites/default/files"
 find "${DOCROOT}/sites/default/files" -type d -exec chmod 2775 {} \;

--- a/.tugboat/steps/2-update.sh
+++ b/.tugboat/steps/2-update.sh
@@ -12,8 +12,8 @@ mv .tugboat .tugboat-tmp
 composer install
 ./vendor/bin/task sync
 
-# Ensure the sites directories are writable.
-chmod 755 ${DOCROOT}/sites/*/
+# Ensure the sites/default directory is writable.
+chmod 755 ${DOCROOT}/sites/default
 
 # Set file permissions such that Drupal will not complain.
 chgrp -R www-data "${DOCROOT}/sites/default/files"

--- a/scaffold/tugboat/settings.tugboat.php.twig
+++ b/scaffold/tugboat/settings.tugboat.php.twig
@@ -33,6 +33,6 @@ if (getenv('TUGBOAT_REPO')) {
   $config['environment_indicator.indicator']['bg_color'] = '#990055';
   $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
 
-  // Prevent Drupal from making the sites/default directory unwritable.
+  // Keep the sites/default directory writable.
   $settings['skip_permissions_hardening'] = TRUE;
 }

--- a/scaffold/tugboat/settings.tugboat.php.twig
+++ b/scaffold/tugboat/settings.tugboat.php.twig
@@ -32,4 +32,7 @@ if (getenv('TUGBOAT_REPO')) {
   $config['environment_indicator.indicator']['name'] = '☑️ Tugboat';
   $config['environment_indicator.indicator']['bg_color'] = '#990055';
   $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+
+  // Prevent Drupal from making the sites/default directory unwritable.
+  $settings['skip_permissions_hardening'] = TRUE;
 }

--- a/scaffold/tugboat/steps/2-update.sh.twig
+++ b/scaffold/tugboat/steps/2-update.sh.twig
@@ -9,8 +9,8 @@ echo "Updating..."
 composer install
 ./vendor/bin/task {{ sync_command }}
 
-# Ensure the sites directories are writable.
-chmod 755 ${DOCROOT}/sites/*/
+# Ensure the sites/default directory is writable.
+chmod 755 ${DOCROOT}/sites/default
 
 # Set file permissions such that Drupal will not complain.
 chgrp -R www-data "${DOCROOT}/sites/default/files"

--- a/scaffold/tugboat/steps/2-update.sh.twig
+++ b/scaffold/tugboat/steps/2-update.sh.twig
@@ -9,6 +9,9 @@ echo "Updating..."
 composer install
 ./vendor/bin/task {{ sync_command }}
 
+# Ensure the sites directories are writable.
+chmod 755 ${DOCROOT}/sites/*/
+
 # Set file permissions such that Drupal will not complain.
 chgrp -R www-data "${DOCROOT}/sites/default/files"
 find "${DOCROOT}/sites/default/files" -type d -exec chmod 2775 {} \;


### PR DESCRIPTION
Fixes https://github.com/Lullabot/drainpipe/issues/866