### PR TITLE
Issue #650: Fix drainpipe-dev tag push and allow phpunit v11 to fix composer conflicts

### DIFF
--- a/.github/workflows/DrainpipeDev.yml
+++ b/.github/workflows/DrainpipeDev.yml
@@ -57,4 +57,4 @@ jobs:
           git reset --mixed origin/${{ github.ref_name }} || git reset --mixed origin/main
           git add -A
           git commit -m "${{ github.event.head_commit.message }}" --allow-empty
-          git push origin ${{ github.ref_name }}
+          git push origin refs/heads/${{ github.ref_name }}

--- a/.github/workflows/DrainpipeDev.yml
+++ b/.github/workflows/DrainpipeDev.yml
@@ -40,40 +40,21 @@ jobs:
           git remote add origin git@github.com:Lullabot/drainpipe-dev.git
           git fetch origin
 
-      - name: Commit changes (Tag)
+      - name: Commit and push changes (Tag)
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         working-directory: drainpipe-dev
         run: |
           git reset --mixed origin/main
           git add -A
           git commit -m "${{ github.ref_name }}" --allow-empty
+          git tag ${{ github.ref_name }}
+          git push origin refs/tags/${{ github.ref_name }}
 
-      - name: Commit changes (Branch)
+      - name: Commit and push changes (Branch)
         if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
         working-directory: drainpipe-dev
         run: |
           git reset --mixed origin/${{ github.ref_name }} || git reset --mixed origin/main
           git add -A
           git commit -m "${{ github.event.head_commit.message }}" --allow-empty
-
-      - name: Tag release
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        working-directory: drainpipe-dev
-        run: |
-          git tag ${{ github.ref_name }}
-
-      - name: Push to drainpipe-dev
-        working-directory: drainpipe-dev
-        run: |
           git push origin ${{ github.ref_name }}
-
-      - name: Create release
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.DRAINPIPE_DEV_RELEASE_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/lullabot/drainpipe-dev/releases \
-            -d '{"tag_name":"${{ github.ref_name }}","name":"${{ github.ref_name }}","body":"See <a href=\"https://github.com/Lullabot/drainpipe/releases/tag/${{ github.ref_name }}\">https://github.com/Lullabot/drainpipe/releases/tag/${{ github.ref_name }}</a>","draft":false,"prerelease":false,"generate_release_notes":false}'

--- a/drainpipe-dev/composer.json
+++ b/drainpipe-dev/composer.json
@@ -23,7 +23,7 @@
         "mockery/mockery": "^1.6.12",
         "phpspec/prophecy-phpunit": "^2",
         "phpstan/phpstan-deprecation-rules": "^2.0.3",
-        "phpunit/phpunit": "^9|^10",
+        "phpunit/phpunit": "^9|^10|^11",
         "symfony/phpunit-bridge": "^6|^7",
         "symfony/yaml": "^6|^7",
         "tijsverkoyen/convert-to-junit-xml": "^1.11.0",


### PR DESCRIPTION
Resolves https://github.com/Lullabot/drainpipe/issues/650

I have tested this with https://github.com/davereid/drainpipe and https://github.com/davereid/drainpipe-dev, which you can see was able to successfully push the latest tag release with this updated workflow:

- https://github.com/davereid/drainpipe-dev/releases/tag/v1.0.2
- https://github.com/davereid/drainpipe/actions/workflows/DrainpipeDev.yml
- https://github.com/davereid/drainpipe-dev/actions/workflows/release.yml

The problem was I was creating both a branch and a tag with the same name, then running `git push origin ${{ github.ref_name }}` and it didn't know to resolve the tag or the branch to push, so it failed.

This also gets rid of creating the release here in the workflow and letting the drainpipe-dev workflow create it when it sees a new tag.