### PR TITLE
Fix uses error in TestAcquia.yml

### DIFF
--- a/.github/workflows/TestAcquia.yml
+++ b/.github/workflows/TestAcquia.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - name: Create a Drupal project
         run: |
-
           composer create-project drupal/recommended-project:10.4.0 . \
             --ignore-platform-req=ext-gd
 
@@ -24,7 +23,8 @@ jobs:
         with:
           path: drainpipe
 
-      - uses: .github/actions/drainpipe/common/set-env
+      - uses: ./drainpipe/scaffold/github/actions/common/set-env
+
       - name: Install DDEV
         uses: ./drainpipe/scaffold/github/actions/common/ddev
         with:
@@ -34,7 +34,6 @@ jobs:
 
       - name: Setup Project
         run: |
-
           ddev config --auto
           ddev start
           ddev exec --raw composer config extra.drupal-scaffold.gitignore true


### PR DESCRIPTION
https://github.com/Lullabot/drainpipe/actions/workflows/TestAcquia.yml has been consistently failing:

```
[Error](https://github.com/Lullabot/drainpipe/actions/runs/16150343553/workflow)
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```