### PR TITLE
Issue #797: Change range strategy to update-lockfile for Symfony packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,7 @@
     },
     {
       "allowedVersions": "^6 || ^7",
+      "rangeStrategy": "update-lockfile",
       "matchPackageNames": [
         "/^symfony//"
       ]


### PR DESCRIPTION
### Relates to:
- #797  

### Description:
- Changes the Renovate configuration for Symfony packages, so the range strategy is set to `update-lockfile`, in order to keep ranges not modified by Renovate.