### PR TITLE
Issue #797: Change range strategy to widen for Symfony and Drush packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,17 +29,17 @@
       "enabled": false
     },
     {
-      "allowedVersions": "^11 || ^12 || ^13",
       "matchPackageNames": [
         "drush/drush"
       ],
+      "allowedVersions": "^11 || ^12 || ^13",
       "rangeStrategy": "widen"
     },
     {
-      "allowedVersions": "^6 || ^7",
       "matchPackageNames": [
         "/^symfony//"
       ],
+      "allowedVersions": "^6 || ^7",
       "rangeStrategy": "widen"
     }
   ]


### PR DESCRIPTION
Resolve #797 

Changes the `rangeStrategy` value to `widen` for Drush and Symfony packages. The behavior has been tested, and is the following:

* If there is an upgrade within the range, nothing is changed. Example: Drush is set to `^11|^12|^13`, and new version `13.6.0` is published. In this case, Renovate will not create a pull request.
* If there is an upgrade higher than the range, Renovate will expand the range. Example: Drush is set to `^11|^12`, and new version `13.6.0` is published. In this case, Renovate will create a pull request to expand the range to `^11|^12|13.6.0`

<img width="642" height="149" alt="image" src="https://github.com/user-attachments/assets/7c958773-c51a-44dc-be96-d082f9658dcc" />
