### PR TITLE
Issue #876: Run cache rebuild before Drupal database update

### DIFF
--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -58,8 +58,8 @@ tasks:
     desc: Run Drupal update tasks after deploying new code
     cmds:
       # See https://www.drush.org/12.x/deploycommand/
-      - ./vendor/bin/drush {{.site}} --yes updatedb --no-cache-clear
       - ./vendor/bin/drush {{.site}} --yes cache:rebuild
+      - ./vendor/bin/drush {{.site}} --yes updatedb --no-cache-clear
       # Run config:import twice to make sure we catch any config that didn't declare
       # a dependency correctly. This is also useful when importing large config sets
       # as it can sometimes hit an out of memory error.


### PR DESCRIPTION
### Relates to:
- #876 

### Description:
Changes the order of cache rebuild and database update commands in the task `drupal:update`, to match what is suggested in the corresponding [Lullabot's ADR](https://architecture.lullabot.com/adr/20230929-drupal-build-steps/).