### PR TITLE
drupal:update is missing one final cache:rebuild after deploy:hook

### DIFF
--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -66,7 +66,6 @@ tasks:
       # as it can sometimes hit an out of memory error.
       - ./vendor/bin/drush {{.site}} --yes config:import || true
       - ./vendor/bin/drush {{.site}} --yes config:import
-      - ./vendor/bin/drush {{.site}} --yes cache:rebuild
       - ./vendor/bin/drush {{.site}} --yes deploy:hook
       - ./vendor/bin/drush {{.site}} --yes cache:rebuild
       - |

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -67,6 +67,7 @@ tasks:
       - ./vendor/bin/drush {{.site}} --yes config:import
       - ./vendor/bin/drush {{.site}} --yes cache:rebuild
       - ./vendor/bin/drush {{.site}} --yes deploy:hook
+      - ./vendor/bin/drush {{.site}} --yes cache:rebuild
       - |
        # drush config:status --format=json is outputting notices in Pantheon even with the json format, 
        # so we need to tail the last line.
@@ -86,3 +87,4 @@ tasks:
     desc: Turn off Maintenance Mode
     cmds:
       - ./vendor/bin/drush {{.site}} --yes state:set system.maintenance_mode 0 --input-format=integer
+      - ./vendor/bin/drush {{.site}} --yes cache:rebuild

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -58,6 +58,7 @@ tasks:
     desc: Run Drupal update tasks after deploying new code
     cmds:
       # See https://www.drush.org/12.x/deploycommand/
+      # See https://architecture.lullabot.com/adr/20230929-drupal-build-steps/
       - ./vendor/bin/drush {{.site}} --yes cache:rebuild
       - ./vendor/bin/drush {{.site}} --yes updatedb --no-cache-clear
       # Run config:import twice to make sure we catch any config that didn't declare


### PR DESCRIPTION
As per https://architecture.lullabot.com/adr/20230929-drupal-build-steps/

```
vendor/bin/drush cache:rebuild --yes
vendor/bin/drush updatedb --yes
# Run config:import twice to make sure we catch any config that didn't declare
# a dependency correctly. This is also useful when importing large config sets
# as it can sometimes hit an out of memory error.
vendor/bin/drush config:import --yes || true
vendor/bin/drush config:import --yes
# Run update hooks that need to be run after config import. These need to be
# written as hook_deploy_NAME() hooks.
vendor/bin/drush deploy:hook --yes
vendor/bin/drush cache:rebuild -y
```

However we are missing that final `cache:rebuild` after running the `deploy:hook` command...

Also we should do a cache rebuild after turning off maintenance mode.