### PR TITLE
Issue #933: pinning PHP distribution on Tugboat to bookworm.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -11,7 +11,7 @@
 services:
   php:
     http: false
-    image: tugboatqa/php-nginx:8.3-fpm
+    image: tugboatqa/php-nginx:8.3-fpm-bookworm
     default: true
 
     depends:

--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -481,7 +481,7 @@ EOT;
         $binaryInstallerPlugin = new BinaryInstallerPlugin();
         $tugboatConfig = [
             'nodejs_version' => '18',
-            'webserver_image' => 'tugboatqa/php-nginx:8.1-fpm',
+            'webserver_image' => 'tugboatqa/php-nginx:8.1-fpm-bookworm',
             'database_type' => 'mariadb',
             'database_version' => '10.11',
             'php_version' => '8.1',
@@ -499,13 +499,13 @@ EOT;
             $ddevConfig = Yaml::parseFile('./.ddev/config.yaml');
             $tugboatConfig['database_type'] = $ddevConfig['database']['type'];
             $tugboatConfig['database_version'] = $ddevConfig['database']['version'];
-            $tugboatConfig['webserver_image'] = 'tugboatqa/php-nginx:' . $ddevConfig['php_version'] . '-fpm';
+            $tugboatConfig['webserver_image'] = 'tugboatqa/php-nginx:' . $ddevConfig['php_version'] . '-fpm-bookworm';
 
             if (!empty($ddevConfig['nodejs_version'])) {
                 $tugboatConfig['nodejs_version'] = $ddevConfig['nodejs_version'];
             }
             if (!empty($ddevConfig['webserver_type']) && $ddevConfig['webserver_type'] === 'apache-fpm') {
-                $tugboatConfig['webserver_image'] = 'tugboatqa/php:' . $ddevConfig['php_version'] . '-apache';
+                $tugboatConfig['webserver_image'] = 'tugboatqa/php:' . $ddevConfig['php_version'] . '-apache-bookworm';
             }
         }
 


### PR DESCRIPTION
This pull request updates the Tugboat service configuration and related installer logic to use the new Bookworm-based PHP images. This ensures consistency and compatibility with the latest Tugboat images across both static configuration and dynamic generation.

**Tugboat Image Updates:**

* [`.tugboat/config.yml`](diffhunk://#diff-fbd0812762ff8d2c67fa66a4956c3b55557ad0889505294f524192000b2ce50eL14-R14): Changed the PHP service image from `tugboatqa/php-nginx:8.3-fpm` to `tugboatqa/php-nginx:8.3-fpm-bookworm` to use the Bookworm-based image.

**Installer Logic Updates:**

* `src/ScaffoldInstallerPlugin.php` (`installTugboat` method): Updated the default webserver image from `tugboatqa/php-nginx:8.1-fpm` to `tugboatqa/php-nginx:8.1-fpm-bookworm` for static configuration.
* `src/ScaffoldInstallerPlugin.php` (`installTugboat` method): When generating the webserver image from DDEV config, appended `-bookworm` to both nginx and apache image tags for dynamic configuration.