### PR TITLE
Use workflow_dispatch in scaffold/github/workflows/PantheonReviewAppsManualDDEV.yml

### DIFF
--- a/scaffold/github/workflows/PantheonReviewAppsManualDDEV.yml
+++ b/scaffold/github/workflows/PantheonReviewAppsManualDDEV.yml
@@ -1,8 +1,7 @@
 name: "Pantheon Review Apps"
 
 on:
-  pull_request:
-    types: [ labeled, unlabeled, opened, synchronize, reopened]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/scaffold/github/workflows/PantheonReviewAppsManualDDEV.yml
+++ b/scaffold/github/workflows/PantheonReviewAppsManualDDEV.yml
@@ -9,7 +9,6 @@ concurrency:
 
 jobs:
   Drainpipe-Deploy-Pantheon-Multidev:
-    if: contains(github.event.pull_request.labels.*.name, 'pantheon-multidev')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
For the manual workflow of PantheonReviewApps, we need to use workflow_dispatch instead of other events.