### PR TITLE
Update task to 3.45.4

### DIFF
--- a/.github/workflows/TestBinaryInstaller.yml
+++ b/.github/workflows/TestBinaryInstaller.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Simulate failure
         run: |
-          ddev exec touch /var/www/html/composer-cache/files/lullabot/drainpipe/bin/task/3.38.0/task_linux_amd64.tar
+          ddev exec touch /var/www/html/composer-cache/files/lullabot/drainpipe/bin/task/3.45.4/task_linux_amd64.tar
           ddev composer install
 
       - name: Test installing without composer cache

--- a/.github/workflows/ValidateTaskfile.yml
+++ b/.github/workflows/ValidateTaskfile.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Validate Taskfile.yml
         # Also update src/BinaryInstallPlugin.php if changing version
         run: |
-          curl -O https://raw.githubusercontent.com/go-task/task/v3.38.0/website/static/schema.json
+          curl -O https://raw.githubusercontent.com/go-task/task/v3.45.4/website/src/public/schema.json
           npx ajv-cli validate -s schema.json -d scaffold/Taskfile.yml

--- a/.tugboat/steps/1-init.sh
+++ b/.tugboat/steps/1-init.sh
@@ -7,7 +7,7 @@ set -eux
 echo "Initializing..."
 
 # Install task
-sh -c "$(curl --location https://raw.githubusercontent.com/go-task/task/v3.38.0/install-task.sh)" -- -d -b /usr/local/bin
+sh -c "$(curl --location https://raw.githubusercontent.com/go-task/task/v3.45.4/install-task.sh)" -- -d -b /usr/local/bin
 
 # Install mysql or mariadb client.
 apt-get update

--- a/scaffold/tugboat/steps/1-init.sh.twig
+++ b/scaffold/tugboat/steps/1-init.sh.twig
@@ -7,7 +7,7 @@ set -eux
 echo "Initializing..."
 
 # Install task
-sh -c "$(curl --location https://raw.githubusercontent.com/go-task/task/v3.38.0/install-task.sh)" -- -d -b /usr/local/bin
+sh -c "$(curl --location https://raw.githubusercontent.com/go-task/task/v3.45.4/install-task.sh)" -- -d -b /usr/local/bin
 
 # Install mysql or mariadb client.
 apt-get update

--- a/src/BinaryInstallerPlugin.php
+++ b/src/BinaryInstallerPlugin.php
@@ -16,24 +16,24 @@ class BinaryInstallerPlugin extends BinaryInstaller
         'task' => [
             'releases' => [
                 'linux' => [
-                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_linux_amd64.tar.gz', 'sha' => 'a6241c9fbcc49bdffef907e4d6325adb074295fd094f2bfa6a2e32282c2ed06e'],
-                    'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_linux_arm.tar.gz', 'sha' => '623d0fdf13b2940495c177f4dce83ec9f2db26645011052280a812a8ba1f146a'],
-                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_linux_386.tar.gz', 'sha' => '4ae95300c51d53f894cce9bc45f22b2347492772b21c3a6ddf3d47304c7bbefa'],
-                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_linux_arm64.tar.gz', 'sha' => '30d3c727a434ee3bf69fb69e5d1aa84c3ab401fc2343a2760b4c7808acc689b8'],
+                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_linux_amd64.tar.gz', 'sha' => '4367eba04abcbcb407578d18d2439ee32604a872419601abec76a829c797fb82'],
+                    'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_linux_arm.tar.gz', 'sha' => '5c221616b42e4fa77d12f58343b80de8426ed33fc776c8d970d5386ee168dab0'],
+                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_linux_386.tar.gz', 'sha' => '8addf48412caae19e083907f3f704c5398e68b38cbcde25d3535198258a5aeab'],
+                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_linux_arm64.tar.gz', 'sha' => '61d773d7a81af2283079e640f14e8aa52a4e793460733a0da37228a283f4ce00'],
                 ],
                 'darwin' => [
-                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_darwin_amd64.tar.gz', 'sha' => 'a2aefff4f3cb2851ce133c13a20502f1dfa8a6bc34d3f4e01c67cf3278f4f73d'],
-                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_darwin_arm64.tar.gz', 'sha' => 'a575c9e10591bb35d1bb678bdde2fa221330d207a787b0a5979d4287ee7f4c0f'],
+                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_darwin_amd64.tar.gz', 'sha' => '6f17b62cf938ab93162b1e59ecb5d1cd046f364bd3609ff4c6fb9e05e86c336e'],
+                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_darwin_arm64.tar.gz', 'sha' => '14ae69f7f161532ea1e187a176de9c963b4431b1b6a60a7fdaa40c1ea8b64b26'],
                 ],
                 'windows' => [
-                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_windows_amd64.zip', 'sha' => '6586105949b4359b37f770b7604542c23f064e055c6521791cd8d5916ec287fb'],
-		            'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_windows_arm.zip', 'sha' => 'cda87056d8289f55d040e413171357ad7b1efaa75ae3c9433106f13a9057053e'],
-                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_windows_arm64.zip', 'sha' => '955e88bb22b3396bd95c9d8d25e8fd71a323364549e012d863287fd069d51ee7'],
-                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.38.0/task_windows_386.zip', 'sha' => '72962ea63388db41750e60cd0184e8c68ffd008ce277ba7502e974e40ee36bf2'],
+                    'amd64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_windows_amd64.zip', 'sha' => '543b70c6cc663f355892f4cc7072bb1c5460ba62dbe95aa0fd4aeb180e4271e1'],
+		            'arm' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_windows_arm.zip', 'sha' => 'd3799eba603c3a567df28c446542bd1dbc134a8299c3e5f9e05b85b41c00bc01'],
+                    'arm64' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_windows_arm64.zip', 'sha' => 'ffafc7adfe2354858ebf24b9fb7622418b235863d5e7574328323474a0c48234'],
+                    '386' => ['url' => 'https://github.com/go-task/task/releases/download/v3.45.4/task_windows_386.zip', 'sha' => 'b8512d43cbdee19ca1cd816fb9b3a78ae3e4b3adaac7ade8816ec5a2e54c7ebd'],
                 ],
             ],
             'hashalgo' => 'sha256',
-            'version' => '3.38.0',
+            'version' => '3.45.4',
         ],
     ];
 


### PR DESCRIPTION
We are currently using v3.38.0 and the latest release is v3.45.4. Let's get this updated, and do a quick review of the releases since to see if there' any new features or bug fixes we might be interested in.

In our project we want to use a new feature introduced in 3.41 (https://github.com/go-task/task/pull/1859)