### PR TITLE
PantheonReviewAppsManual should trigger with workflow_dispatch only, conditions should not evaluate PR-only variables

### DIFF
--- a/scaffold/github/workflows/PantheonReviewAppsManual.yml
+++ b/scaffold/github/workflows/PantheonReviewAppsManual.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 # You will also need to add the secrets used below to Dependabot secrets
@@ -16,7 +16,6 @@ permissions:
 
 jobs:
   Drainpipe-Deploy-Pantheon-Multidev:
-    if: contains(github.event.pull_request.labels.*.name, 'pantheon-multidev')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/scaffold/github/workflows/PantheonReviewAppsManualDDEV.yml
+++ b/scaffold/github/workflows/PantheonReviewAppsManualDDEV.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Very similar issue here: https://github.com/Lullabot/drainpipe/pull/942

- PantheonReviewAppsManual 
  - should trigger with workflow_dispatch only
  - improves/fixes workflow's concurrency
  - avoids conditions with undefined variables (previously defined on PR events) to avoid failure