### PR TITLE
Avoid cache issue when extracting binaries

### DIFF
--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -69,7 +69,7 @@ tasks:
       - ./vendor/bin/drush {{.site}} --yes deploy:hook
       - ./vendor/bin/drush {{.site}} --yes cache:rebuild
       - |
-       # drush config:status --format=json is outputting notices in Pantheon even with the json format,
+       # drush config:status --format=json is outputting notices in Pantheon even with the json format, 
        # so we need to tail the last line.
         config_status_output=$(./vendor/bin/drush {{.site}} config:status --format=json --state=Different | tail -n1)
         if [[ $config_status_output != '[]' ]]; then


### PR DESCRIPTION
This PR avoids issues when extracting binaries.
The issue was replicated on a client's repo and fixed on the latest update of this branch.

Now it creates a temporary directory to extract binaries, and moves them to the right place later if possible (using a `try finally` block).



