### PR TITLE
Disable non-major Node updates for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,11 @@
       ],
       "allowedVersions": "^6 || ^7",
       "rangeStrategy": "widen"
+    },
+    {
+      "matchDatasources": ["node-version"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This pull request disables all non-major updates for Node JS - we require `.nvmrc` file to contain only the major version number