### PR TITLE
999: Remove use of unsupported `local-php-security-checker` tool

### DIFF
--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -35,22 +35,6 @@ tasks:
   security:
     desc: Runs security checks for composer packages and Drupal contrib
     cmds:
-      - cmd: |
-          if [ "{{.format}}" == "junit" ]; then
-            mkdir -p test_result
-            ./vendor/bin/local-php-security-checker --format=json > test_result/local-php-security-checker.json
-          fi
-        ignore_error: true
-      - |
-        if [ "{{.format}}" == "junit" ]; then
-          RESULT=$(cat test_result/local-php-security-checker.json)
-          ./vendor/bin/drainpipe-convert-to-junit-xml convert:sensiolabs-security-check "$RESULT" > test_result/local-php-security-checker.xml
-          if [ "$RESULT" != "{}" ]; then
-            exit 1
-          fi
-        else
-          ./vendor/bin/local-php-security-checker
-        fi
       - composer audit
       - |
         ./vendor/bin/composer-lock-diff --from {{ shellQuote (.composer_lock_diff_from | default "main") }} --md


### PR DESCRIPTION
Fixes https://github.com/Lullabot/drainpipe/issues/999

`local-php-security-checker` is no longer supported and the project recommends using `composer audit` instead, which we are already doing. So this removes the use of the old tool while leaving use of `composer audit` in place.