### PR TITLE
Remove --verbose from drush core:cron command

### DIFF
--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -78,7 +78,7 @@ tasks:
           exit 1;
         fi
       # Run cron after updating to refresh items.
-      - ./vendor/bin/drush {{ .site }} core:cron --verbose
+      - ./vendor/bin/drush {{ .site }} core:cron
   maintenance:on:
     desc: Turn on Maintenance Mode
     cmds:


### PR DESCRIPTION
My logs for builds (on a site that deploys multiple sites in parallel) are often filled with a lot of Drush verbose output on cron:

```
[update:all] [site]      [drupal:update]  [info] Drush bootstrap phase: bootstrapDrupalRoot()
[update:all] [site]      [drupal:update]  [info] Change working directory to /var/lib/tugboat/web
[update:all] [site]      [drupal:update]  [info] Initialized Drupal 11.2.8 root directory at /var/lib/tugboat/web
[update:all] [site]      [drupal:update]  [info] Drush bootstrap phase: bootstrapDrupalSite()
[update:all] [site]      [drupal:update]  [info] Initialized Drupal site site-ulzl3zdhpmsglbvcfjspenhutcwc4vqj.tugboatqa.com at sites/site
[update:all] [site]      [drupal:update]  [info] Drush bootstrap phase: bootstrapDrupalConfiguration()
[update:all] [site]      [drupal:update]  [info] Drush bootstrap phase: bootstrapDrupalDatabase()
[update:all] [site]      [drupal:update]  [info] Successfully connected to the Drupal database.
[update:all] [site]      [drupal:update]  [info] Drush bootstrap phase: bootstrapDrupalFull()
[update:all] [site]      [drupal:update]  [info] Starting bootstrap to none
[update:all] [site]      [drupal:update]  [info] Drush bootstrap phase 0
[update:all] [site]      [drupal:update]  [info] Try to validate bootstrap phase 0
[update:all] [site]      [drupal:update]  [info] Starting execution of dblog_cron().
[update:all] [site]      [drupal:update]  [info] Starting execution of field_cron(), execution of dblog_cron() took 1.81ms.
[update:all] [site]      [drupal:update]  [info] Starting execution of file_cron(), execution of field_cron() took 0.8ms.
[update:all] [site]      [drupal:update]  [info] Starting execution of layout_builder_cron(), execution of file_cron() took 21.09ms.
[update:all] [site]      [drupal:update]  [info] Starting execution of lightning_scheduler_cron(), execution of layout_builder_cron() took 0.01ms.
[update:all] [site]      [drupal:update]  [info] Starting execution of node_cron(), execution of lightning_scheduler_cron() took 63.75ms.
[update:all] [site]      [drupal:update]  [info] Starting execution of search_cron(), execution of node_cron() took 7.93ms.
[update:all] [site]      [drupal:update]  [info] Starting execution of system_cron(), execution of search_cron() took 5.93ms.
[update:all] [site]      [drupal:update]  [info] Starting execution of trash_cron(), execution of system_cron() took 32.48ms.
[update:all] [site]      [drupal:update]  [info] Starting execution of update_cron(), execution of trash_cron() took 0.17ms.
[update:all] [site]      [drupal:update]  [info] Execution of update_cron() took 1258.68ms.
[update:all] [site]      [drupal:update]  [info] Cron run completed.
```

Maybe there's an alternate command we could use that could compromise in the amount of debugging shown?