### PR TITLE
#1049 Improving consistency in obtaining/determining Node version

### DIFF
--- a/scaffold/github/actions/common/set-env/action.yml
+++ b/scaffold/github/actions/common/set-env/action.yml
@@ -53,11 +53,11 @@ runs:
 
     - run: |
         if [[ -f .nvmrc ]]; then
-            NODE_VERSION_RAW=$(cat .nvmrc)
+            NODE_FILE=.nvmrc
         else
-            NODE_VERSION_RAW=$(cat drainpipe/.nvmrc)
+            NODE_FILE=drainpipe/.nvmrc
         fi
-        NODE_MAJOR=$(echo "${NODE_VERSION_RAW}" | tr -d '[:space:]')
+        NODE_MAJOR=$(tr -d '[:space:]' < "$NODE_FILE")
         echo "NODE_MAJOR=${NODE_MAJOR}" >> "$GITHUB_ENV"
 
       shell: bash


### PR DESCRIPTION
Closes: #1049 

<img width="1447" height="790" alt="image" src="https://github.com/user-attachments/assets/025a31f2-b61a-4486-9a51-95c2020508b5" />

The current command has a bug due to shell operator precedence. The pipe | has higher precedence than && and ||, so tr -d '[:space:]' is only applied when .nvmrc is not found. This can lead to NODE_MAJOR having trailing whitespace if .nvmrc exists and contains it.