### PR TITLE
Issue #1060: Add a "Build Project" step to the "Composer-Audit" job

### DIFF
--- a/scaffold/github/workflows/Security.yml
+++ b/scaffold/github/workflows/Security.yml
@@ -117,6 +117,11 @@ jobs:
           git-name: Drainpipe Bot
           git-email: no-reply@example.com
 
+      - name: Build Project
+        run:  |
+          ddev composer install --no-plugins
+          ddev composer install
+
       - name: Run composer audit
         run: ddev exec bash ./vendor/lullabot/drainpipe/scripts/composer-audit.sh
 


### PR DESCRIPTION
This PR fixes the `No such file or directory` error in the `Composer-Audit` job within the Security workflow on GitHub Actions.

```console
bash: ./vendor/lullabot/drainpipe/scripts/composer-audit.sh: No such file or directory
Failed to execute command `bash ./vendor/lullabot/drainpipe/scripts/composer-audit.sh`: exit status 127
Error: Process completed with exit code 127.
```