### PR TITLE
Update README about correct key to enable Terminus in Tugboat

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,7 +803,7 @@ Additionally, Pantheon Terminus can be added:
     "extra": {
         "drainpipe": {
             "tugboat": {
-              "pantheon": true
+                "pantheon": true
             }
         }
     }


### PR DESCRIPTION
The `ScaffoldInstallerPlugin` expects the `pantheon` flag instead of `terminus`. This pull request fixes the reference in the `README.md` file