### PR TITLE
1124: Silence SASS deprecation warnings (do not merge).

### DIFF
--- a/metapackages/sass/gulpfile.js
+++ b/metapackages/sass/gulpfile.js
@@ -36,6 +36,7 @@ const includes = Object.keys(srcs)
     const result = dartSass.renderSync({
       file: file,
       includePaths: [modernNormalizePath],
+      silenceDeprecations: ['legacy-js-api'],
     });
     return result.stats.includedFiles.filter(file => typeof file === "string");
   })
@@ -48,6 +49,7 @@ task('sass', function() {
     .pipe(sass.sync({
       outputStyle: 'compressed',
       includePaths: [modernNormalizePath],
+      silenceDeprecations: ['legacy-js-api'],
     }).on('error', sass.logError))
     .pipe(postcss([
       autoprefixer(),


### PR DESCRIPTION
Fixes https://github.com/Lullabot/drainpipe/issues/1124

This is a temporary hack to silence the deprecation warnings when running `task sass`. It is not the correct solution but it shows where the problem lies in the current SASS compilation warnings.