### PR TITLE
chore: improve how taskfile includes are detected in Taskfile.yml

### DIFF
--- a/src/ScaffoldInstallerPlugin.php
+++ b/src/ScaffoldInstallerPlugin.php
@@ -162,7 +162,10 @@ class ScaffoldInstallerPlugin implements PluginInterface, EventSubscriberInterfa
             $projectTaskfile = Yaml::parseFile('./Taskfile.yml');
             $missingIncludes = [];
             foreach ($scaffoldTaskFile['includes'] as $key => $value) {
-                if (empty($projectTaskfile['includes'][$key]) || $projectTaskfile['includes'][$key] !== $value) {
+                $scaffoldPath = is_array($value) ? ($value['taskfile'] ?? '') : $value;
+                $projectValue = $projectTaskfile['includes'][$key] ?? null;
+                $projectPath = is_array($projectValue) ? ($projectValue['taskfile'] ?? '') : (string) $projectValue;
+                if ($scaffoldPath !== $projectPath) {
                     $missingIncludes[] = $key;
                 }
             }


### PR DESCRIPTION
A `Taskfile.yml` whose `includes` section looks like this will have the three elements detected as missing when Drainpipe checks the file:
```
includes:
  deploy:
    taskfile: ./vendor/lullabot/drainpipe/tasks/deploy.yml
    optional: true
  drupal:
    taskfile: ./vendor/lullabot/drainpipe/tasks/drupal.yml
    optional: true
  tugboat:
    taskfile: ./vendor/lullabot/drainpipe/tasks/tugboat.yml
    optional: true
```

This is the current output of Drainpipe's warning for a Taskfile like the above:
```
Taskfile.yml has either been customized or requires review. Currently the following includes are missing or outdated:
  - deploy: ./vendor/lullabot/drainpipe/tasks/deploy.yml
  - drupal: ./vendor/lullabot/drainpipe/tasks/drupal.yml
  - tugboat: ./vendor/lullabot/drainpipe/tasks/tugboat.yml
Compare Taskfile.yml includes in the root of your repository with vendor/lullabot/drainpipe/scaffold/Taskfile.yml and update as needed.
```

The reason behind this situation is the detection logic for the includes expects them to be a single string, when it may be an object under some circumstances (like in the example above).

This pull request improves the logic to detect those includes present in the Taskfile to prevent notifying about includes that are actually there.