### PR TITLE
fix: #766 support ed25519 keys

### DIFF
--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -17,59 +17,46 @@ inputs:
     description: "Composer cache directory, relative to the project workspace. Set to false to disable."
     required: false
   version:
-    description: "Override the DDEV version .e.g. '1.19.0'"
+    description: "Override the DDEV version e.g. '1.19.0'"
     required: false
 runs:
   using: "composite"
   steps:
-    - name: Install and Start DDEV
+    - name: Configure SSH keys
+      shell: bash
       env:
         INPUT_SSH_PRIVATE_KEY: ${{ inputs.ssh-private-key }}
         INPUT_SSH_KNOWN_HOSTS: ${{ inputs.ssh-known-hosts }}
-        INPUT_VERSION: ${{ inputs.version }}
-        INPUT_COMPOSER_CACHE_DIR: ${{ inputs.composer-cache-dir }}
-        INPUT_GIT_NAME: ${{ inputs.git-name }}
-        INPUT_GIT_EMAIL: ${{ inputs.git-email }}
       run: |
-        curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -
-        echo "deb https://apt.fury.io/drud/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list
-        sudo apt update
-        sudo apt install libnss3-tools -y
-
         mkdir -p .ddev/homeadditions/.ssh
         touch .ddev/homeadditions/.ssh/config
-        # Copy private key
         if [ "$INPUT_SSH_PRIVATE_KEY" != "" ]; then
           echo "$INPUT_SSH_PRIVATE_KEY" > .ddev/homeadditions/.ssh/id_drainpipe
           chmod 600 .ddev/homeadditions/.ssh/id_drainpipe
           echo "IdentityFile ~/.ssh/id_drainpipe" >> .ddev/homeadditions/.ssh/config
         fi
-        # Copy known hosts
         if [ "$INPUT_SSH_KNOWN_HOSTS" != "" ]; then
           echo "$INPUT_SSH_KNOWN_HOSTS" > .ddev/homeadditions/.ssh/known_hosts
           chmod 644 .ddev/homeadditions/.ssh/known_hosts
         fi
-
-        # Disable strict host key checking for Pantheon as ssh-keyscan will not
-        # return a stable response.
         if [ -f "pantheon.yml" ]; then
           echo -e "Host *.drush.in\\n\\tStrictHostKeyChecking no\\n\tLogLevel ERROR\\n" >> .ddev/homeadditions/.ssh/config
         fi
-
         chmod 600 .ddev/homeadditions/.ssh/config
         chmod 700 .ddev/homeadditions/.ssh
 
-        # Download and run the DDEV installer
-        if [ "$INPUT_VERSION" != "" ]; then
-          sudo apt install -y ddev=$INPUT_VERSION
-        else
-          sudo apt install -y ddev
-        fi
+    - name: Install DDEV
+      uses: ddev/github-action-setup-ddev@fdf2f5c97943bae638f31df6df86f1defa6210c0 # v1
+      with:
+        version: ${{ inputs.version || 'latest' }}
+        autostart: 'false'
 
-        ddev config global --instrumentation-opt-in=false --omit-containers=ddev-ssh-agent
-
+    - name: Configure Composer cache and start DDEV
+      shell: bash
+      env:
+        INPUT_COMPOSER_CACHE_DIR: ${{ inputs.composer-cache-dir }}
+      run: |
         if [ "$INPUT_COMPOSER_CACHE_DIR" != "false" ]; then
-          # @todo Replace /var/www/html with an environment variable.
           CACHE_DIR=".ddev/.drainpipe-composer-cache"
           if [ "$INPUT_COMPOSER_CACHE_DIR" != "" ]; then
             CACHE_DIR="$INPUT_COMPOSER_CACHE_DIR"
@@ -81,13 +68,15 @@ runs:
             ddev config --web-environment-add="COMPOSER_CACHE_DIR=/var/www/html/$CACHE_DIR"
           fi
         fi
-
         ddev start
         ddev describe
 
-        # Copy git credentials
+    - name: Configure git credentials
+      shell: bash
+      env:
+        INPUT_GIT_NAME: ${{ inputs.git-name }}
+        INPUT_GIT_EMAIL: ${{ inputs.git-email }}
+      run: |
         ddev exec "git config --global user.name \"$INPUT_GIT_NAME\""
         ddev exec "git config --global user.email \"$INPUT_GIT_EMAIL\""
-
         echo "DRAINPIPE_DDEV=true" >> $GITHUB_ENV
-      shell: bash

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -39,8 +39,8 @@ runs:
         mkdir -p .ddev/homeadditions/.ssh
         # Copy private key
         if [ "$INPUT_SSH_PRIVATE_KEY" != "" ]; then
-          echo "$INPUT_SSH_PRIVATE_KEY" > .ddev/homeadditions/.ssh/id_rsa
-          chmod 600 .ddev/homeadditions/.ssh/id_rsa
+          echo "$INPUT_SSH_PRIVATE_KEY" > .ddev/homeadditions/.ssh/id_drainpipe
+          chmod 600 .ddev/homeadditions/.ssh/id_drainpipe
         fi
         # Copy known hosts
         if [ "$INPUT_SSH_KNOWN_HOSTS" != "" ]; then
@@ -49,6 +49,9 @@ runs:
         fi
         # SSH config file
         touch .ddev/homeadditions/.ssh/config
+        if [ "$INPUT_SSH_PRIVATE_KEY" != "" ]; then
+          echo "IdentityFile ~/.ssh/id_drainpipe" >> .ddev/homeadditions/.ssh/config
+        fi
 
         # Disable strict host key checking for Pantheon as ssh-keyscan will not
         # return a stable response.

--- a/scaffold/github/actions/common/ddev/action.yml
+++ b/scaffold/github/actions/common/ddev/action.yml
@@ -37,20 +37,17 @@ runs:
         sudo apt install libnss3-tools -y
 
         mkdir -p .ddev/homeadditions/.ssh
+        touch .ddev/homeadditions/.ssh/config
         # Copy private key
         if [ "$INPUT_SSH_PRIVATE_KEY" != "" ]; then
           echo "$INPUT_SSH_PRIVATE_KEY" > .ddev/homeadditions/.ssh/id_drainpipe
           chmod 600 .ddev/homeadditions/.ssh/id_drainpipe
+          echo "IdentityFile ~/.ssh/id_drainpipe" >> .ddev/homeadditions/.ssh/config
         fi
         # Copy known hosts
         if [ "$INPUT_SSH_KNOWN_HOSTS" != "" ]; then
           echo "$INPUT_SSH_KNOWN_HOSTS" > .ddev/homeadditions/.ssh/known_hosts
           chmod 644 .ddev/homeadditions/.ssh/known_hosts
-        fi
-        # SSH config file
-        touch .ddev/homeadditions/.ssh/config
-        if [ "$INPUT_SSH_PRIVATE_KEY" != "" ]; then
-          echo "IdentityFile ~/.ssh/id_drainpipe" >> .ddev/homeadditions/.ssh/config
         fi
 
         # Disable strict host key checking for Pantheon as ssh-keyscan will not
@@ -60,7 +57,6 @@ runs:
         fi
 
         chmod 600 .ddev/homeadditions/.ssh/config
-
         chmod 700 .ddev/homeadditions/.ssh
 
         # Download and run the DDEV installer

--- a/scaffold/gitlab/DDEV.gitlab-ci.yml
+++ b/scaffold/gitlab/DDEV.gitlab-ci.yml
@@ -27,26 +27,23 @@ cache:
     - sudo chown -R runner:runner $CI_PROJECT_DIR
     - |
       mkdir -p .ddev/homeadditions/.ssh
+      touch .ddev/homeadditions/.ssh/config
       # Copy private key
       if [ "$DRAINPIPE_SSH_PRIVATE_KEY_BASE64" != "" ]; then
         echo "$DRAINPIPE_SSH_PRIVATE_KEY_BASE64" | base64 -d > .ddev/homeadditions/.ssh/id_drainpipe
         chmod 600 .ddev/homeadditions/.ssh/id_drainpipe
+        echo "IdentityFile ~/.ssh/id_drainpipe" >> .ddev/homeadditions/.ssh/config
       elif [ "$DRAINPIPE_DDEV_SSH_PRIVATE_KEY" != "" ]; then
         echo "$DRAINPIPE_DDEV_SSH_PRIVATE_KEY" > .ddev/homeadditions/.ssh/id_drainpipe
         chmod 600 .ddev/homeadditions/.ssh/id_drainpipe
+        echo "IdentityFile ~/.ssh/id_drainpipe" >> .ddev/homeadditions/.ssh/config
       fi
       # Copy known hosts
       if [ "$DRAINPIPE_DDEV_SSH_KNOWN_HOSTS" != "" ]; then
         echo "$DRAINPIPE_DDEV_SSH_KNOWN_HOSTS" > .ddev/homeadditions/.ssh/known_hosts
         chmod 644 .ddev/homeadditions/.ssh/known_hosts
       fi
-      # SSH config file
-      touch .ddev/homeadditions/.ssh/config
-      if [ "$DRAINPIPE_SSH_PRIVATE_KEY_BASE64" != "" ] || [ "$DRAINPIPE_DDEV_SSH_PRIVATE_KEY" != "" ]; then
-        echo "IdentityFile ~/.ssh/id_drainpipe" >> .ddev/homeadditions/.ssh/config
-      fi
       chmod 600 .ddev/homeadditions/.ssh/config
-
       chmod 700 .ddev/homeadditions/.ssh
     - |
       if [ "$DRAINPIPE_DDEV_VERSION" != "" ]; then

--- a/scaffold/gitlab/DDEV.gitlab-ci.yml
+++ b/scaffold/gitlab/DDEV.gitlab-ci.yml
@@ -29,11 +29,11 @@ cache:
       mkdir -p .ddev/homeadditions/.ssh
       # Copy private key
       if [ "$DRAINPIPE_SSH_PRIVATE_KEY_BASE64" != "" ]; then
-        echo "$DRAINPIPE_SSH_PRIVATE_KEY_BASE64" | base64 -d > .ddev/homeadditions/.ssh/id_rsa
-        chmod 600 .ddev/homeadditions/.ssh/id_rsa
+        echo "$DRAINPIPE_SSH_PRIVATE_KEY_BASE64" | base64 -d > .ddev/homeadditions/.ssh/id_drainpipe
+        chmod 600 .ddev/homeadditions/.ssh/id_drainpipe
       elif [ "$DRAINPIPE_DDEV_SSH_PRIVATE_KEY" != "" ]; then
-        echo "$DRAINPIPE_DDEV_SSH_PRIVATE_KEY" > .ddev/homeadditions/.ssh/id_rsa
-        chmod 600 .ddev/homeadditions/.ssh/id_rsa
+        echo "$DRAINPIPE_DDEV_SSH_PRIVATE_KEY" > .ddev/homeadditions/.ssh/id_drainpipe
+        chmod 600 .ddev/homeadditions/.ssh/id_drainpipe
       fi
       # Copy known hosts
       if [ "$DRAINPIPE_DDEV_SSH_KNOWN_HOSTS" != "" ]; then
@@ -42,6 +42,9 @@ cache:
       fi
       # SSH config file
       touch .ddev/homeadditions/.ssh/config
+      if [ "$DRAINPIPE_SSH_PRIVATE_KEY_BASE64" != "" ] || [ "$DRAINPIPE_DDEV_SSH_PRIVATE_KEY" != "" ]; then
+        echo "IdentityFile ~/.ssh/id_drainpipe" >> .ddev/homeadditions/.ssh/config
+      fi
       chmod 600 .ddev/homeadditions/.ssh/config
 
       chmod 700 .ddev/homeadditions/.ssh


### PR DESCRIPTION
Closes #766 

The DDEV SSH setup in both the GitHub Actions composite action and the GitLab CI include was hardcoding the SSH key filename as `id_rsa`, which breaks `ed25519` keys since OpenSSH probes identity files by name. This pull request writes the key to a neutral filename (`id_drainpipe`) and adds an explicit `IdentityFile ~/.ssh/id_drainpipe` directive to `~/.ssh/config`, making the approach key-type-agnostic.