### PR TITLE
fix: remove unused GitHub API token inputs from action.yml

### DIFF
--- a/scaffold/github/actions/common/set-env/action.yml
+++ b/scaffold/github/actions/common/set-env/action.yml
@@ -1,12 +1,5 @@
 name: 'Set Env'
 description: 'Creates some useful environment variables'
-inputs:
-  github-api-token:
-    description: "GitHub API token"
-    required: true
-  github-api-token-username:
-    description: "GitHub API token username"
-    required: true
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
I keep seeing errors when using `./.github/actions/drainpipe/set-env` in my project.

<img width="1045" height="141" alt="image" src="https://github.com/user-attachments/assets/87c658ef-462a-4361-bf44-fc69a8666057" />

I went to look at the action and I don't see any usages of `github-api-token` nor `github-api-token-username` can we just remove them?