### PR TITLE
Reference class path with 'use'  for EnvironmentDetector

### DIFF
--- a/scaffold/acquia/settings.acquia.php
+++ b/scaffold/acquia/settings.acquia.php
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Acquia\Drupal\RecommendedSettings\Helpers\EnvironmentDetector;
+
 if (getenv('AH_SITE_ENVIRONMENT')) {
   // If trusted_reverse_proxy_ips is not defined, fail gracefully.
   // phpcs:ignore


### PR DESCRIPTION
Avoids a fatal error when scaffolding the `settings.acquia.php` file