### PR TITLE
fix: #1242 Ensure Drainpipe 6.x can be installed for Drupal 10 and 11

### DIFF
--- a/drainpipe-dev/composer.json
+++ b/drainpipe-dev/composer.json
@@ -16,7 +16,7 @@
         "behat/mink": "^1.13.0",
         "behat/mink-browserkit-driver": "^2.3.0",
         "davidrjonas/composer-lock-diff": "^1.7.1",
-        "drupal/coder": "^9.0.0",
+        "drupal/coder": "^8||^9",
         "lullabot/drainpipe": "*",
         "lullabot/twig-cs-fixer-drupal": "^2.1.0",
         "mglaman/phpstan-drupal": "^1||^2",

--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,17 @@
       "allowedVersions": "^9 || ^10 || ^11"
     },
     {
+      "description": "Widen drupal/coder range in drainpipe-dev (coder ^8 for D10/D11, ^9 for D12)",
+      "matchPackageNames": [
+        "drupal/coder"
+      ],
+      "matchFileNames": [
+        "drainpipe-dev/composer.json"
+      ],
+      "rangeStrategy": "widen",
+      "allowedVersions": "^8 || ^9"
+    },
+    {
       "automerge": false,
       "matchPackageNames": [
         "drush/drush",


### PR DESCRIPTION
Closes #1242